### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ matplotlib >= 2.0.0
 intervaltree >= 2.1.0
 pybigwig >= 0.3.7
 future >= 0.16.0
-hicexplorer >= 1.8
+hicexplorer >= 2.0
 pytest
 


### PR DESCRIPTION
This line needs at least HicExplorer version 2.0 (and in 2.1 it is failing because I remove the line which I shouldn't. Maybe version 2.1.1 should be the dependecy).
https://github.com/deeptools/pyGenomeTracks/blob/master/pygenometracks/tracksClass.py#L1726