### PR TITLE
Fixing scale labels and pep

### DIFF
--- a/pygenometracks/tracksClass.py
+++ b/pygenometracks/tracksClass.py
@@ -455,15 +455,16 @@ class XAxisTrack(GenomeTrack):
 
     def plot(self, ax, chrom_region, region_start, region_end):
         ticks = ax.get_xticks()
-        if ticks[-1] - ticks[1] <= 1e5:
+        if ticks[-1] - ticks[1] <= 1e3:
+            labels = ["{:,.0f}".format((x))
+                      for x in ticks]
+            labels[-2] += " b"
+
+        elif ticks[-1] - ticks[1] <= 4e5:
             labels = ["{:,.0f}".format((x / 1e3))
                       for x in ticks]
             labels[-2] += " Kb"
 
-        elif 1e5 < ticks[-1] - ticks[1] < 4e6:
-            labels = ["{:,.0f}".format((x / 1e3))
-                      for x in ticks]
-            labels[-2] += " Kb"
         else:
             labels = ["{:,.1f} ".format((x / 1e6))
                       for x in ticks]


### PR DESCRIPTION
Values in a range of < 1e3 are currently just displayed as 0. This patch is fixing this.