### PR TITLE
Fixing bug concerning log and -log option for Hi-C matrices

### DIFF
--- a/pygenometracks/tracks/HiCMatrixTrack.py
+++ b/pygenometracks/tracks/HiCMatrixTrack.py
@@ -196,13 +196,19 @@ file_type = {}
 
             elif self.properties['transform'] == '-log':
                 mask = matrix == 0
-                matrix[mask] = matrix[mask is False].min()
-                matrix = -1 * np.log(matrix)
+                try:
+                    matrix[mask] = matrix[mask == False].min()
+                    matrix = -1 * np.log(matrix)
+                except Exception:
+                    self.log.info('All values are 0, no log applied.')
 
             elif self.properties['transform'] == 'log':
                 mask = matrix == 0
-                matrix[mask] = matrix[mask is False].min()
-                matrix = np.log(matrix)
+                try:
+                    matrix[mask] = matrix[mask == False].min()
+                    matrix = np.log(matrix)
+                except Exception:
+                    self.log.info('All values are 0, no log applied.')
 
         if 'max_value' in self.properties and self.properties['max_value'] != 'auto':
             vmax = self.properties['max_value']

--- a/pygenometracks/tracks/HiCMatrixTrack.py
+++ b/pygenometracks/tracks/HiCMatrixTrack.py
@@ -199,7 +199,7 @@ file_type = {}
                 try:
                     matrix[mask] = matrix[mask == False].min()
                     matrix = -1 * np.log(matrix)
-                except Exception:
+                except ValueError:
                     self.log.info('All values are 0, no log applied.')
 
             elif self.properties['transform'] == 'log':
@@ -207,7 +207,7 @@ file_type = {}
                 try:
                     matrix[mask] = matrix[mask == False].min()
                     matrix = np.log(matrix)
-                except Exception:
+                except ValueError:
                     self.log.info('All values are 0, no log applied.')
 
         if 'max_value' in self.properties and self.properties['max_value'] != 'auto':


### PR DESCRIPTION
It is `mask == False` and not `mask is False`. First one checks if the entries of `mask` are `False` and creates a boolean array with the result , second one checks if `mask` object is `False`. Adding catch for possible case all values in the matrix are 0.