### PR TITLE
hacky xaxis overlap fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pyGenomeTracks can make plots with or without Hi-C data. The following is an exa
 
 Installation
 ------------
-pyGenomeTracks works with python 2.7 and python 3.6.
+pyGenomeTracks works with python >=3.6.
 
 Currently, the best way to install pyGenomeTracks is with anaconda
 
@@ -167,7 +167,7 @@ Examples with peaks
 
 pyGenomeTracks has an option to plot peaks using MACS2 narrowPeak format.
 
-The following is an example of the output in which the peak shape is 
+The following is an example of the output in which the peak shape is
 drawn based on the start, end, summit and height of the peak.
 
 ```INI
@@ -345,7 +345,7 @@ The configuration file for this image is [here](./pygenometracks/tests/test_data
 
 Adding new tracks
 -----------------
-Adding new tracks to pyGenomeTracks only requires adding a new class to the `pygenometracks/tracks` folder. 
+Adding new tracks to pyGenomeTracks only requires adding a new class to the `pygenometracks/tracks` folder.
 The class should inherit the the `GenomeTrack` (or other track class available) and should have a `plot` method.
 Additionally, some basic description should be added.
 
@@ -378,7 +378,7 @@ x position =
 
 ```
 
-The OPTIONS_TXT should contain the text to build a default configuration file. 
+The OPTIONS_TXT should contain the text to build a default configuration file.
 This information, together with the information about SUPPORTED_ENDINGS is used
 by the program `make_tracks_file` to create a default configuration file
 based on the endings of the files given.
@@ -405,29 +405,29 @@ pgt --tracks new_track.ini --region X:3000000-3200000 -o new_track.png
 
 ![pyGenomeTracks example](./examples/new_track.png)
 
-Notice that the resulting track already includes a y-axis (to the left) and 
+Notice that the resulting track already includes a y-axis (to the left) and
 a label to the right. This are the defaults that can be changed by
-adding a `plot_y_axis` and `plot_label` methods. 
+adding a `plot_y_axis` and `plot_label` methods.
 
 Another more complex example is the plotting of multiple bedgraph data as matrices. The output of `HiCExplorer hicFindTADs` produces a data format that
 is similar to a bedgraph but with more value columns. We call this a bedgraph matrix. The following track plot this bedgraph matrix:
- 
+
  ```python
 import numpy as np
 from pygenometracks.tracksClass import BedGraphTrack
 from pygenometracks.tracksClass import GenomeTrack
 
  class BedGraphMatrixTrack(BedGraphTrack):
-    # this track class extends a BedGraphTrack that is already part of 
+    # this track class extends a BedGraphTrack that is already part of
     # pyGenomeTracks. The advantage of extending this class is that
     # we can re-use the code for reading a bedgraph file
     SUPPORTED_ENDINGS = ['.bm', '.bm.gz']
     TRACK_TYPE = 'bedgraph_matrix'
     OPTIONS_TXT = GenomeTrack.OPTIONS_TXT + """
         # a bedgraph matrix file is like a bedgraph, except that per bin there
-        # are more than one value (separated by tab). This file type is 
+        # are more than one value (separated by tab). This file type is
         # produced by the HiCExplorer tool hicFindTads and contains
-        # the TAD-separation score at different window sizes. 
+        # the TAD-separation score at different window sizes.
         # E.g.
         # chrX	18279	40131	0.399113	0.364118	0.320857	0.274307
         # chrX	40132	54262	0.479340	0.425471	0.366541	0.324736
@@ -450,21 +450,21 @@ from pygenometracks.tracksClass import GenomeTrack
         # here we used the get_scores method inherited from the
         # BedGraphTrack class
         values_list, start_pos = self.get_scores(chrom_region, start_region, end_region)
-        
+
         # the values_list is a python list, containing one element
         # per row in the selected genomic range.
         # In this case, the bedgraph matrix contains per row a list
         # of values, thus, each element of the values_list is itself
-        # a list. 
+        # a list.
         # In the following code, such list is converted to floats and
-        # appended to a new list. 
+        # appended to a new list.
         matrix_rows = []
         for values in values_list:
             values = map(float, values)
             matrix_rows.append(values)
 
         # using numpy, the list of values per line in the bedgraph file
-        # is converted into a matrix whose columns contain 
+        # is converted into a matrix whose columns contain
         # the bedgraph values for the same line (notice that
         # the matrix is transposed to achieve this)
         matrix = np.vstack(matrix_rows).T
@@ -509,7 +509,7 @@ pgt --tracks bedgraph_matrix.ini --region X:2000000-3500000 -o bedgraph_matrix.p
 ![pyGenomeTracks example](./examples/bedgraph_matrix.png)
 
 Although this image looks interesting another way to plot
-the data is a overlapping lines with the mean value highlighted. 
+the data is a overlapping lines with the mean value highlighted.
 Using the bedgraph version of `pyGenomeTracks` the following image
 can be obtained:
 

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,6 @@ dependencies:
     - matplotlib >= 2.0.0
     - intervaltree >= 2.1.0
     - pybigwig >= 0.3.7
-    - future >= 0.16.0
     - hicexplorer >= 2.1.1
     - pysam >= 0.14
     - pytest

--- a/pygenometracks/_version.py
+++ b/pygenometracks/_version.py
@@ -2,4 +2,4 @@
 # This file is originally generated from Git information by running 'setup.py
 # version'. Distribution tarballs contain a pre-generated copy of this file.
 
-__version__ = '2.1'
+__version__ = '3.0'

--- a/pygenometracks/plotTracks.py
+++ b/pygenometracks/plotTracks.py
@@ -141,10 +141,8 @@ type = vlines
 
 """
 
-from __future__ import division
 import sys
 import argparse
-
 import matplotlib
 matplotlib.use('Agg')
 
@@ -295,8 +293,12 @@ def main(args=None):
 
             file_name = "{}_{}-{}-{}.{}".format(file_prefix, chrom, start, end, file_suffix)
             if end - start < 200000:
-                start -= 100000
-                end += 100000
+                sys.stderr.write("A region shorter than 200kb has been "
+                                 "detected! This can be too small to return "
+                                 "a proper TAD plot!\n")
+                # start -= 100000
+                # start = max(0, start)
+                # end += 100000
             sys.stderr.write("saving {}\n".format(file_name))
             print("{} {} {}".format(chrom, start, end))
             trp.plot(file_name, chrom, start, end, title=args.title)

--- a/pygenometracks/readBed.py
+++ b/pygenometracks/readBed.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division
-
 import sys
 import collections
 from .utilities import to_string

--- a/pygenometracks/tests/test_make_tracks.py
+++ b/pygenometracks/tests/test_make_tracks.py
@@ -19,6 +19,7 @@ def test_make_tracks():
 
     if filecmp.cmp(outfile.name, ROOT + 'master_tracks.ini') is False:
         import difflib
+
         diff = difflib.unified_diff(open(outfile.name).readlines(),
                                     open(ROOT + 'master_tracks.ini').readlines(), lineterm='')
         print(''.join(list(diff)))

--- a/pygenometracks/tracks/BedGraphMatrixTrack.py
+++ b/pygenometracks/tracks/BedGraphMatrixTrack.py
@@ -1,6 +1,7 @@
 from . BedGraphTrack import BedGraphTrack
 from . GenomeTrack import GenomeTrack
 import numpy as np
+import matplotlib.pyplot as plt
 
 
 class BedGraphMatrixTrack(BedGraphTrack):
@@ -54,9 +55,10 @@ file_type = {}
         Plots a bedgraph matrix file, that instead of having
         a single value per bin, it has several values.
         """
-
-        values_list, start_pos = self.get_scores(chrom_region, start_region, end_region)
-
+        try:
+            values_list, start_pos = self.get_scores(chrom_region, start_region, end_region)
+        except TypeError:
+            return
         matrix_rows = []
         for values in values_list:
             values = list(map(float, values))
@@ -108,9 +110,10 @@ file_type = {}
         if self.properties['type'] == 'lines':
             super(BedGraphMatrixTrack, self).plot_y_axis(ax, plot_axis)
         else:
-            import matplotlib.pyplot as plt
-
-            cobar = plt.colorbar(self.img, ax=ax, fraction=0.95)
+            try:
+                cobar = plt.colorbar(self.img, ax=ax, fraction=0.95)
+            except AttributeError:
+                return
 
             cobar.solids.set_edgecolor("face")
             cobar.ax.tick_params(labelsize='smaller')

--- a/pygenometracks/tracks/BedGraphTrack.py
+++ b/pygenometracks/tracks/BedGraphTrack.py
@@ -1,6 +1,7 @@
 from . GenomeTrack import GenomeTrack
 from .. utilities import file_to_intervaltree
 import numpy as np
+import sys
 
 DEFAULT_BEDGRAPH_COLOR = '#a6cee3'
 
@@ -126,12 +127,31 @@ file_type = {}
         pos_list = []
         if self.tbx is not None:
             if chrom_region not in self.tbx.contigs:
+                chrom_region_before = chrom_region
                 chrom_region = self.change_chrom_names(chrom_region)
-            chrom_region = self.check_chrom_str_bytes(self.tbx.contigs, chrom_region)
+                if chrom_region not in self.tbx.contigs:
+                    sys.stderr.write("*Error*\nNeither"
+                                     " " + chrom_region_before + " nor"
+                                     " " + chrom_region + " exits as a "
+                                     "chromosome name inside the provided "
+                                     "file.\n")
+                    return
+
+            chrom_region = self.check_chrom_str_bytes(self.tbx.contigs,
+                                                      chrom_region)
             iterator = self.tbx.fetch(chrom_region, start_region, end_region)
+
         else:
             if chrom_region not in list(self.interval_tree):
+                chrom_region_before = chrom_region
                 chrom_region = self.change_chrom_names(chrom_region)
+                if chrom_region not in list(self.interval_tree):
+                    sys.stderr.write("*Error*\nNeither"
+                                     " " + chrom_region_before + " nor"
+                                     " " + chrom_region + " exits as a "
+                                     "chromosome name inside the bedgraph "
+                                     "file.\n")
+                    return
             chrom_region = self.check_chrom_str_bytes(self.interval_tree, chrom_region)
             iterator = iter(sorted(self.interval_tree[chrom_region][start_region - 10000:end_region + 10000]))
 

--- a/pygenometracks/tracks/BedTrack.py
+++ b/pygenometracks/tracks/BedTrack.py
@@ -241,7 +241,13 @@ file_type = {}
             self.get_max_num_row(self.len_w, self.small_relative)
 
         if chrom_region not in self.interval_tree.keys():
+            chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
+            if chrom_region not in self.interval_tree.keys():
+                self.log.error("*Error*\nNeither " + chrom_region_before + " "
+                               "nor " + chrom_region + " exits as a chromosome"
+                               " name inside the bed file.\n")
+                return
         chrom_region = self.check_chrom_str_bytes(self.interval_tree, chrom_region)
 
         genes_overlap = sorted(self.interval_tree[chrom_region][start_region:end_region])

--- a/pygenometracks/tracks/BigWigTrack.py
+++ b/pygenometracks/tracks/BigWigTrack.py
@@ -83,7 +83,14 @@ file_type = {}
                                                                                self.properties['file']))
 
         if chrom_region not in self.bw.chroms().keys():
+            chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
+            if chrom_region not in self.bw.chroms().keys():
+                self.log.error("*Error*\nNeither " + chrom_region_before + " "
+                               "nor " + chrom_region + " exits as a chromosome"
+                               " name inside the bigwig file.\n")
+                return
+
         chrom_region = self.check_chrom_str_bytes(self.bw.chroms().keys(), chrom_region)
 
         if chrom_region not in self.bw.chroms().keys():
@@ -119,7 +126,7 @@ file_type = {}
         x_values = np.linspace(start_region, end_region, num_bins)
         if self.plot_type == 'line':
             if self.properties['color'] == self.properties['negative color']:
-                    ax.plot(x_values, scores_per_bin, '-', linewidth=self.size, color=self.properties['color'])
+                ax.plot(x_values, scores_per_bin, '-', linewidth=self.size, color=self.properties['color'])
             else:
                 import warnings
                 warnings.warn('Line plots with a different negative color might not look pretty')

--- a/pygenometracks/tracks/EpilogosTrack.py
+++ b/pygenometracks/tracks/EpilogosTrack.py
@@ -73,8 +73,11 @@ categories_file = <path to json categories file>
         """
         from matplotlib import cm
         cmap = cm.get_cmap('tab20b')
+        try:
+            values_list, pos_list = self.get_scores(chrom_region, start_region, end_region)
+        except TypeError:
+            return
 
-        values_list, pos_list = self.get_scores(chrom_region, start_region, end_region)
         ymin = float('Inf')
         ymax = -float('Inf')
 

--- a/pygenometracks/tracks/HiCMatrixTrack.py
+++ b/pygenometracks/tracks/HiCMatrixTrack.py
@@ -147,7 +147,13 @@ file_type = {}
         log.debug('chrom_region {}, region_start {}, region_end {}'.format(chrom_region, region_start, region_end))
         chrom_sizes = self.hic_ma.get_chromosome_sizes()
         if chrom_region not in chrom_sizes:
+            chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
+            if chrom_region not in chrom_sizes:
+                self.log.error("*Error*\nNeither " + chrom_region_before + " "
+                               "nor " + chrom_region + " exits as a chromosome"
+                               " name on the matrix.\n")
+                return
 
         chrom_region = self.check_chrom_str_bytes(chrom_sizes, chrom_region)
         if region_end > chrom_sizes[chrom_region]:
@@ -256,9 +262,15 @@ file_type = {}
             formatter = LogFormatter(10, labelOnlyBase=False)
             aa = np.array([1, 2, 5])
             tick_values = np.concatenate([aa * 10 ** x for x in range(10)])
-            cobar = plt.colorbar(self.img, ticks=tick_values, format=formatter, ax=cbar_ax, fraction=0.95)
+            try:
+                cobar = plt.colorbar(self.img, ticks=tick_values, format=formatter, ax=cbar_ax, fraction=0.95)
+            except AttributeError:
+                return
         else:
-            cobar = plt.colorbar(self.img, ax=cbar_ax, fraction=0.95)
+            try:
+                cobar = plt.colorbar(self.img, ax=cbar_ax, fraction=0.95)
+            except AttributeError:
+                return
 
         cobar.solids.set_edgecolor("face")
         cobar.ax.tick_params(labelsize='smaller')

--- a/pygenometracks/tracks/LinksTrack.py
+++ b/pygenometracks/tracks/LinksTrack.py
@@ -115,7 +115,14 @@ file_type = {}
         count = 0
 
         if chrom_region not in list(self.interval_tree):
+            chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
+            if chrom_region not in list(self.interval_tree):
+                self.log.error("*Error*\nNeither " + chrom_region_before + " "
+                               "nor " + chrom_region + " exits as a chromosome"
+                               " name inside the link file.\n")
+                return
+
         chrom_region = self.check_chrom_str_bytes(self.interval_tree, chrom_region)
 
         arcs_in_region = sorted(self.interval_tree[chrom_region][region_start:region_end])

--- a/pygenometracks/tracks/TADsTrack.py
+++ b/pygenometracks/tracks/TADsTrack.py
@@ -17,8 +17,13 @@ class TADsTrack(BedTrack):
             orig = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
             chrom_region = self.check_chrom_str_bytes(self.interval_tree, chrom_region)
-            self.log.info('Chromosome name: {} does not exists. Changing name to {}'.format(orig, chrom_region))
-
+            self.log.info('Chromosome name: {} does not exists. Changing'
+                          ' name to {}'.format(orig, chrom_region))
+            if chrom_region not in self.interval_tree:
+                self.log.error("*Error*\nNeither " + orig + " "
+                               "nor " + chrom_region + " exits as a chromosome"
+                               " name.\n")
+                return
         for region in sorted(self.interval_tree[chrom_region][start_region:end_region]):
             """
                    ______ y2

--- a/pygenometracks/tracksClass.py
+++ b/pygenometracks/tracksClass.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-from __future__ import division
 
 import logging
 from configparser import ConfigParser
-
+from ast import literal_eval
+import time
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
@@ -109,16 +109,11 @@ class PlotTracks(object):
             if 'title' in properties:
                 # adjust titles that are too long
                 # if the track label space is small
+                assert(sys.version_info[0] != 2)
                 if track_label_width < 0.1:
-                    if sys.version_info[0] == 2:
-                        properties['title'] = textwrap.fill(properties['title'].encode("UTF-8"), 12)
-                    else:
-                        properties['title'] = textwrap.fill(properties['title'], 12)
+                    properties['title'] = textwrap.fill(properties['title'], 12)
                 else:
-                    if sys.version_info[0] == 2:
-                        properties['title'] = textwrap.fill(properties['title'].encode("UTF-8"), 30)
-                    else:
-                        properties['title'] = textwrap.fill(properties['title'], 30)
+                    properties['title'] = textwrap.fill(properties['title'], 30)
 
         log.info("time initializing track(s):")
         self.print_elapsed(start)
@@ -305,7 +300,6 @@ class PlotTracks(object):
         :param tracks_file: file path containing the track configuration
         :return: array of dictionaries and vlines_file. One dictionary per track
         """
-        from ast import literal_eval
         parser = ConfigParser(dict_type=MultiDict, strict=False)
         parser.read_file(open(tracks_file, 'r'))
 
@@ -435,7 +429,6 @@ class PlotTracks(object):
 
     @staticmethod
     def print_elapsed(start):
-        import time
         if start:
             log.info(time.time() - start)
         return time.time()

--- a/pygenometracks/tracksClass.py
+++ b/pygenometracks/tracksClass.py
@@ -477,11 +477,12 @@ class XAxisTrack(GenomeTrack):
             label_y_pos = 0.99
             vert_align = 'top'
         else:
-            ax.axis["x"] = ax.new_floating_axis(0, 0.9)
-            label_y_pos = 0.01
-            vert_align = 'bottom'
+            ax.axis["x"] = ax.new_floating_axis(0, 0.99) #create a little more room
+            label_y_pos = 0
+            vert_align = 'top' # this probably causes text to go beyond axis lims desired- but makes more space
         ax.text(0.5, label_y_pos, chrom_region, horizontalalignment='center',
-                fontsize=int(self.properties['fontsize']), verticalalignment=vert_align, transform=ax.transAxes)
+                fontsize=int(self.properties['fontsize']), verticalalignment=vert_align, transform=ax.transAxes,
+				clip_on=False) # in practice I need to set another spacer below to avoid clipping
 
         ax.axis["x"].axis.set_ticklabels(labels)
         ax.axis['x'].axis.set_tick_params(which='minor', bottom='on')

--- a/pygenometracks/utilities.py
+++ b/pygenometracks/utilities.py
@@ -1,4 +1,5 @@
 import sys
+import gzip
 from intervaltree import IntervalTree, Interval
 
 
@@ -9,8 +10,9 @@ def to_string(s):
     if isinstance(s, str):
         return s
     if isinstance(s, bytes):
-        if sys.version_info[0] == 2:
-            return str(s)
+        assert(sys.version_info[0] != 2)
+#        if sys.version_info[0] == 2:
+#            return str(s)
         return s.decode('ascii')
     if isinstance(s, list):
         return [to_string(x) for x in s]
@@ -21,8 +23,9 @@ def to_bytes(s):
     """
     Like toString, but for functions requiring bytes in python3
     """
-    if sys.version_info[0] == 2:
-        return s
+    assert(sys.version_info[0] != 2)
+#    if sys.version_info[0] == 2:
+#        return s
     if isinstance(s, bytes):
         return s
     if isinstance(s, str):
@@ -36,7 +39,6 @@ def opener(filename):
     """
     Determines if a file is compressed or not
     """
-    import gzip
     f = open(filename, 'rb')
     if f.read(2) == b'\x1f\x8b':
         f.seek(0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy >= 1.15
+numpy >= 1.16
 matplotlib
 intervaltree
 pybigwig

--- a/setup.py
+++ b/setup.py
@@ -97,9 +97,8 @@ install_requires_py = ["numpy >= 1.12.1",
                        "matplotlib >= 2.0.0",
                        "intervaltree >= 2.1.0",
                        "pyBigWig >=0.3.7",
-                       "future >= 0.16.0",
-                       "hicmatrix",
-                       "pysam",
+                       "hicexplorer >= 2.1.1",
+                       "pysam>=0.14",
                        "pytest"
                        ]
 
@@ -124,6 +123,6 @@ setup(
         'Topic :: Scientific/Engineering :: Bio-Informatics'],
     install_requires=install_requires_py,
     zip_safe=False,
-    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4',
+    python_requires='>=3.6.*, <4',
     cmdclass={'sdist': sdist, 'install': install}
 )


### PR DESCRIPTION
Here is a hacky fix to stop the xaxis ticklabels from overlapping the chromosome label.  I think a better solution would be to allow the user to increase the height of the Xaxis track such that the text could comfortably fit with your original settings, but I couldn't figure out where such a thing was set.  In principle, this fix will cause text to extend below the bounds of a default XaxisTrack, thus inserting a spacer below the track is necessary too. 