### PR TITLE
Add gtf possibility and other small things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ htmlcov
 .mr.developer.cfg
 .project
 .pydevproject
+
+# vscode
+.vscode

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pyGenomeTracks can make plots with or without Hi-C data. The following is an exa
 
 Installation
 ------------
-pyGenomeTracks works with python 2.7 and python 3.6.
+pyGenomeTracks works with python >=3.6.
 
 Currently, the best way to install pyGenomeTracks is with anaconda
 
@@ -167,7 +167,7 @@ Examples with peaks
 
 pyGenomeTracks has an option to plot peaks using MACS2 narrowPeak format.
 
-The following is an example of the output in which the peak shape is 
+The following is an example of the output in which the peak shape is
 drawn based on the start, end, summit and height of the peak.
 
 ```INI
@@ -345,7 +345,7 @@ The configuration file for this image is [here](./pygenometracks/tests/test_data
 
 Adding new tracks
 -----------------
-Adding new tracks to pyGenomeTracks only requires adding a new class to the `pygenometracks/tracks` folder. 
+Adding new tracks to pyGenomeTracks only requires adding a new class to the `pygenometracks/tracks` folder.
 The class should inherit the the `GenomeTrack` (or other track class available) and should have a `plot` method.
 Additionally, some basic description should be added.
 
@@ -378,7 +378,7 @@ x position =
 
 ```
 
-The OPTIONS_TXT should contain the text to build a default configuration file. 
+The OPTIONS_TXT should contain the text to build a default configuration file.
 This information, together with the information about SUPPORTED_ENDINGS is used
 by the program `make_tracks_file` to create a default configuration file
 based on the endings of the files given.
@@ -405,29 +405,29 @@ pgt --tracks new_track.ini --region X:3000000-3200000 -o new_track.png
 
 ![pyGenomeTracks example](./examples/new_track.png)
 
-Notice that the resulting track already includes a y-axis (to the left) and 
+Notice that the resulting track already includes a y-axis (to the left) and
 a label to the right. This are the defaults that can be changed by
-adding a `plot_y_axis` and `plot_label` methods. 
+adding a `plot_y_axis` and `plot_label` methods.
 
 Another more complex example is the plotting of multiple bedgraph data as matrices. The output of `HiCExplorer hicFindTADs` produces a data format that
 is similar to a bedgraph but with more value columns. We call this a bedgraph matrix. The following track plot this bedgraph matrix:
- 
+
  ```python
 import numpy as np
 from pygenometracks.tracksClass import BedGraphTrack
 from pygenometracks.tracksClass import GenomeTrack
 
  class BedGraphMatrixTrack(BedGraphTrack):
-    # this track class extends a BedGraphTrack that is already part of 
+    # this track class extends a BedGraphTrack that is already part of
     # pyGenomeTracks. The advantage of extending this class is that
     # we can re-use the code for reading a bedgraph file
     SUPPORTED_ENDINGS = ['.bm', '.bm.gz']
     TRACK_TYPE = 'bedgraph_matrix'
     OPTIONS_TXT = GenomeTrack.OPTIONS_TXT + """
         # a bedgraph matrix file is like a bedgraph, except that per bin there
-        # are more than one value (separated by tab). This file type is 
+        # are more than one value (separated by tab). This file type is
         # produced by the HiCExplorer tool hicFindTads and contains
-        # the TAD-separation score at different window sizes. 
+        # the TAD-separation score at different window sizes.
         # E.g.
         # chrX	18279	40131	0.399113	0.364118	0.320857	0.274307
         # chrX	40132	54262	0.479340	0.425471	0.366541	0.324736
@@ -450,21 +450,21 @@ from pygenometracks.tracksClass import GenomeTrack
         # here we used the get_scores method inherited from the
         # BedGraphTrack class
         values_list, start_pos = self.get_scores(chrom_region, start_region, end_region)
-        
+
         # the values_list is a python list, containing one element
         # per row in the selected genomic range.
         # In this case, the bedgraph matrix contains per row a list
         # of values, thus, each element of the values_list is itself
-        # a list. 
+        # a list.
         # In the following code, such list is converted to floats and
-        # appended to a new list. 
+        # appended to a new list.
         matrix_rows = []
         for values in values_list:
             values = map(float, values)
             matrix_rows.append(values)
 
         # using numpy, the list of values per line in the bedgraph file
-        # is converted into a matrix whose columns contain 
+        # is converted into a matrix whose columns contain
         # the bedgraph values for the same line (notice that
         # the matrix is transposed to achieve this)
         matrix = np.vstack(matrix_rows).T
@@ -509,7 +509,7 @@ pgt --tracks bedgraph_matrix.ini --region X:2000000-3500000 -o bedgraph_matrix.p
 ![pyGenomeTracks example](./examples/bedgraph_matrix.png)
 
 Although this image looks interesting another way to plot
-the data is a overlapping lines with the mean value highlighted. 
+the data is a overlapping lines with the mean value highlighted.
 Using the bedgraph version of `pyGenomeTracks` the following image
 can be obtained:
 

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,6 @@ dependencies:
     - matplotlib >= 2.0.0
     - intervaltree >= 2.1.0
     - pybigwig >= 0.3.7
-    - future >= 0.16.0
     - hicexplorer >= 2.1.1
     - pysam >= 0.14
     - pytest

--- a/pygenometracks/_version.py
+++ b/pygenometracks/_version.py
@@ -2,4 +2,4 @@
 # This file is originally generated from Git information by running 'setup.py
 # version'. Distribution tarballs contain a pre-generated copy of this file.
 
-__version__ = '2.1'
+__version__ = '3.0'

--- a/pygenometracks/plotTracks.py
+++ b/pygenometracks/plotTracks.py
@@ -141,10 +141,8 @@ type = vlines
 
 """
 
-from __future__ import division
 import sys
 import argparse
-
 import matplotlib
 matplotlib.use('Agg')
 
@@ -295,8 +293,12 @@ def main(args=None):
 
             file_name = "{}_{}-{}-{}.{}".format(file_prefix, chrom, start, end, file_suffix)
             if end - start < 200000:
-                start -= 100000
-                end += 100000
+                sys.stderr.write("A region shorter than 200kb has been "
+                                 "detected! This can be too small to return "
+                                 "a proper TAD plot!\n")
+                # start -= 100000
+                # start = max(0, start)
+                # end += 100000
             sys.stderr.write("saving {}\n".format(file_name))
             print("{} {} {}".format(chrom, start, end))
             trp.plot(file_name, chrom, start, end, title=args.title)

--- a/pygenometracks/readBed.py
+++ b/pygenometracks/readBed.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division
-
 import sys
 import collections
 from .utilities import to_string

--- a/pygenometracks/readBed.py
+++ b/pygenometracks/readBed.py
@@ -11,9 +11,9 @@ class ReadBed(object):
     are bed3, bed6 and bed12
 
     Example:
-    bed = readBed(open("file.bed", 'r'))
+    bed = ReadBed(open("file.bed", 'r'))
     for interval in bed:
-        print bed['start']
+        print interval.start
 
     """
 

--- a/pygenometracks/readGtf.py
+++ b/pygenometracks/readGtf.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+import collections
+
+import gffutils
+
+
+class ReadGtf(object):
+    """
+    Reads a gtf file.
+
+    Example:
+    gtf = ReadGtf("file.gtf")
+    for interval in gtf:
+        print interval.start
+
+    """
+
+    def __init__(self, file_path):
+        """
+        :param file_path: the path of the gtf file
+        :return:
+        """
+
+        self.file_type = 'bed12'
+
+        # list of bed fields
+        self.fields = ['chromosome', 'start', 'end',
+                       'name', 'score', 'strand',
+                       'thick_start', 'thick_end',
+                       'rgb', 'block_count',
+                       'block_sizes', 'block_starts']
+
+        self.BedInterval = collections.namedtuple('BedInterval', self.fields)
+
+        # Will process the gtf to get one item per transcript:
+        # This will create a database:
+        self.db = gffutils.create_db(file_path, ':memory:')
+        # I think the name which should be written
+        # should be the transcript_name
+        # But we can change it to gene_name
+        self.prefered_name = "transcript_name"
+        # prefered_name = "gene_name"
+        self.all_transcripts = self.db.features_of_type("transcript",
+                                                        order_by='start')
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        """
+        :return: bedInterval object
+        """
+        bed = self.get_bed_interval()
+
+        return bed
+
+    def __next__(self):
+        """
+        :return: bedInterval object
+        """
+        bed = self.get_bed_interval()
+
+        return bed
+
+    def get_bed_interval(self):
+        r"""
+        Processes a transcript from the database,
+        retrieve all the values and returns
+        a namedtuple object
+        """
+        tr = next(self.all_transcripts)
+        # The name would be the prefered_name if exists
+        try:
+            trName = tr.attributes[self.prefered_name][0]
+        except KeyError:
+            # Else try to guess the prefered_name from exons:
+            try:
+                trName = set([e.attributes[self.prefered_name][0]
+                              for e in
+                              self.db.children(tr,
+                                               featuretype='exon',
+                                               order_by='start')]).pop()
+            except KeyError:
+                # Else take the transcript id
+                trName = tr.id
+        # If the cds is defined in the gtf,
+        # use it to define the thick start and end
+        # The gtf is 1-based closed intervalls
+        # and bed are 0-based half-open so:
+        # I need to remove one from each start
+        try:
+            cds_start = next(self.db.children(tr,
+                                              featuretype='CDS',
+                                              order_by='start')).start - 1
+            cds_end = next(self.db.children(tr,
+                                            featuretype='CDS',
+                                            order_by='-start')).end
+        except StopIteration:
+            # If the CDS is not defined, then it is set to the start
+            # as proposed here:
+            # https://genome.ucsc.edu/FAQ/FAQformat.html#format1
+            cds_start = tr.start - 1
+            cds_end = tr.start - 1
+        # Get all exons starts and end to get lengths
+        exons_starts = [e.start - 1
+                        for e in self.db.children(tr,
+                                                  featuretype='exon',
+                                                  order_by='start')]
+        exons_ends = [e.end
+                      for e in self.db.children(tr,
+                                                featuretype='exon',
+                                                order_by='start')]
+        exons_length = [e - s for s, e in zip(exons_starts, exons_ends)]
+        relative_exons_starts = [s - (tr.start - 1) for s in exons_starts]
+        line_values = [tr.chrom, tr.start - 1, tr.end, trName, 0, tr.strand,
+                       cds_start, cds_end, "0", len(exons_starts),
+                       exons_length, relative_exons_starts]
+        return self.BedInterval._make(line_values)

--- a/pygenometracks/tests/test_make_tracks.py
+++ b/pygenometracks/tests/test_make_tracks.py
@@ -19,6 +19,7 @@ def test_make_tracks():
 
     if filecmp.cmp(outfile.name, ROOT + 'master_tracks.ini') is False:
         import difflib
+
         diff = difflib.unified_diff(open(outfile.name).readlines(),
                                     open(ROOT + 'master_tracks.ini').readlines(), lineterm='')
         print(''.join(list(diff)))

--- a/pygenometracks/tracks/BedGraphMatrixTrack.py
+++ b/pygenometracks/tracks/BedGraphMatrixTrack.py
@@ -1,6 +1,7 @@
 from . BedGraphTrack import BedGraphTrack
 from . GenomeTrack import GenomeTrack
 import numpy as np
+import matplotlib.pyplot as plt
 
 
 class BedGraphMatrixTrack(BedGraphTrack):
@@ -54,9 +55,10 @@ file_type = {}
         Plots a bedgraph matrix file, that instead of having
         a single value per bin, it has several values.
         """
-
-        values_list, start_pos = self.get_scores(chrom_region, start_region, end_region)
-
+        try:
+            values_list, start_pos = self.get_scores(chrom_region, start_region, end_region)
+        except TypeError:
+            return
         matrix_rows = []
         for values in values_list:
             values = list(map(float, values))
@@ -108,9 +110,10 @@ file_type = {}
         if self.properties['type'] == 'lines':
             super(BedGraphMatrixTrack, self).plot_y_axis(ax, plot_axis)
         else:
-            import matplotlib.pyplot as plt
-
-            cobar = plt.colorbar(self.img, ax=ax, fraction=0.95)
+            try:
+                cobar = plt.colorbar(self.img, ax=ax, fraction=0.95)
+            except AttributeError:
+                return
 
             cobar.solids.set_edgecolor("face")
             cobar.ax.tick_params(labelsize='smaller')

--- a/pygenometracks/tracks/BedGraphTrack.py
+++ b/pygenometracks/tracks/BedGraphTrack.py
@@ -1,6 +1,7 @@
 from . GenomeTrack import GenomeTrack
 from .. utilities import file_to_intervaltree
 import numpy as np
+import sys
 
 DEFAULT_BEDGRAPH_COLOR = '#a6cee3'
 
@@ -126,12 +127,31 @@ file_type = {}
         pos_list = []
         if self.tbx is not None:
             if chrom_region not in self.tbx.contigs:
+                chrom_region_before = chrom_region
                 chrom_region = self.change_chrom_names(chrom_region)
-            chrom_region = self.check_chrom_str_bytes(self.tbx.contigs, chrom_region)
+                if chrom_region not in self.tbx.contigs:
+                    sys.stderr.write("*Error*\nNeither"
+                                     " " + chrom_region_before + " nor"
+                                     " " + chrom_region + " exits as a "
+                                     "chromosome name inside the provided "
+                                     "file.\n")
+                    return
+
+            chrom_region = self.check_chrom_str_bytes(self.tbx.contigs,
+                                                      chrom_region)
             iterator = self.tbx.fetch(chrom_region, start_region, end_region)
+
         else:
             if chrom_region not in list(self.interval_tree):
+                chrom_region_before = chrom_region
                 chrom_region = self.change_chrom_names(chrom_region)
+                if chrom_region not in list(self.interval_tree):
+                    sys.stderr.write("*Error*\nNeither"
+                                     " " + chrom_region_before + " nor"
+                                     " " + chrom_region + " exits as a "
+                                     "chromosome name inside the bedgraph "
+                                     "file.\n")
+                    return
             chrom_region = self.check_chrom_str_bytes(self.interval_tree, chrom_region)
             iterator = iter(sorted(self.interval_tree[chrom_region][start_region - 10000:end_region + 10000]))
 

--- a/pygenometracks/tracks/BedTrack.py
+++ b/pygenometracks/tracks/BedTrack.py
@@ -241,7 +241,13 @@ file_type = {}
             self.get_max_num_row(self.len_w, self.small_relative)
 
         if chrom_region not in self.interval_tree.keys():
+            chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
+            if chrom_region not in self.interval_tree.keys():
+                self.log.error("*Error*\nNeither " + chrom_region_before + " "
+                               "nor " + chrom_region + " exits as a chromosome"
+                               " name inside the bed file.\n")
+                return
         chrom_region = self.check_chrom_str_bytes(self.interval_tree, chrom_region)
 
         genes_overlap = sorted(self.interval_tree[chrom_region][start_region:end_region])

--- a/pygenometracks/tracks/BedTrack.py
+++ b/pygenometracks/tracks/BedTrack.py
@@ -466,7 +466,10 @@ file_type = {}
         for idx in range(0, bed.block_count):
             x0 = bed.start + bed.block_starts[idx]
             x1 = x0 + bed.block_sizes[idx]
-            if x0 < bed.thick_start < x1:
+            if bed.thick_start == bed.thick_end:
+                positions.append((x0, x1, 'UTR'))
+
+            elif x0 < bed.thick_start < x1:
                 positions.append((x0, bed.thick_start, 'UTR'))
                 positions.append((bed.thick_start, x1, 'coding'))
 
@@ -573,7 +576,8 @@ file_type = {}
         for idx in range(0, bed.block_count):
             x0 = bed.start + bed.block_starts[idx]
             x1 = x0 + bed.block_sizes[idx]
-            if x1 < bed.thick_start or x0 > bed.thick_end:
+            if x1 < bed.thick_start or x0 > bed.thick_end or \
+               bed.thick_start == bed.thick_end:
                 y0 = ypos + quarter_height
                 y1 = ypos + three_quarter_height
             else:

--- a/pygenometracks/tracks/BedTrack.py
+++ b/pygenometracks/tracks/BedTrack.py
@@ -1,5 +1,6 @@
 from . GenomeTrack import GenomeTrack
 from .. readBed import ReadBed
+from .. readGtf import ReadGtf
 from matplotlib.patches import Rectangle
 import matplotlib
 from .. utilities import opener
@@ -10,7 +11,9 @@ DEFAULT_BED_COLOR = '#1f78b4'
 
 
 class BedTrack(GenomeTrack):
-    SUPPORTED_ENDINGS = ['bed', 'bed3', 'bed6', 'bed12', 'bed.gz', 'bed3.gz', 'bed6.gz', 'bed12.gz']
+    SUPPORTED_ENDINGS = ['bed', 'bed3', 'bed6', 'bed12',
+                         'bed.gz', 'bed3.gz', 'bed6.gz', 'bed12.gz',
+                         'gtf', 'gtf.gz']
     TRACK_TYPE = 'bed'
     OPTIONS_TXT = GenomeTrack.OPTIONS_TXT + """
 # if the type=genes is given
@@ -144,7 +147,12 @@ file_type = {}
 
     def process_bed(self):
 
-        bed_file_h = ReadBed(opener(self.properties['file']))
+        if self.properties['file'].endswith('gtf') or \
+           self.properties['file'].endswith('gtf.gz') or \
+           ('type' in self.properties and self.properties['type'] == 'gtf'):
+            bed_file_h = ReadGtf(self.properties['file'])
+        else:
+            bed_file_h = ReadBed(opener(self.properties['file']))
         self.bed_type = bed_file_h.file_type
 
         if 'color' in self.properties and self.properties['color'] == 'bed_rgb' and \

--- a/pygenometracks/tracks/BigWigTrack.py
+++ b/pygenometracks/tracks/BigWigTrack.py
@@ -83,7 +83,14 @@ file_type = {}
                                                                                self.properties['file']))
 
         if chrom_region not in self.bw.chroms().keys():
+            chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
+            if chrom_region not in self.bw.chroms().keys():
+                self.log.error("*Error*\nNeither " + chrom_region_before + " "
+                               "nor " + chrom_region + " exits as a chromosome"
+                               " name inside the bigwig file.\n")
+                return
+
         chrom_region = self.check_chrom_str_bytes(self.bw.chroms().keys(), chrom_region)
 
         if chrom_region not in self.bw.chroms().keys():
@@ -119,7 +126,7 @@ file_type = {}
         x_values = np.linspace(start_region, end_region, num_bins)
         if self.plot_type == 'line':
             if self.properties['color'] == self.properties['negative color']:
-                    ax.plot(x_values, scores_per_bin, '-', linewidth=self.size, color=self.properties['color'])
+                ax.plot(x_values, scores_per_bin, '-', linewidth=self.size, color=self.properties['color'])
             else:
                 import warnings
                 warnings.warn('Line plots with a different negative color might not look pretty')

--- a/pygenometracks/tracks/EpilogosTrack.py
+++ b/pygenometracks/tracks/EpilogosTrack.py
@@ -73,8 +73,11 @@ categories_file = <path to json categories file>
         """
         from matplotlib import cm
         cmap = cm.get_cmap('tab20b')
+        try:
+            values_list, pos_list = self.get_scores(chrom_region, start_region, end_region)
+        except TypeError:
+            return
 
-        values_list, pos_list = self.get_scores(chrom_region, start_region, end_region)
         ymin = float('Inf')
         ymax = -float('Inf')
 

--- a/pygenometracks/tracks/HiCMatrixTrack.py
+++ b/pygenometracks/tracks/HiCMatrixTrack.py
@@ -147,7 +147,13 @@ file_type = {}
         log.debug('chrom_region {}, region_start {}, region_end {}'.format(chrom_region, region_start, region_end))
         chrom_sizes = self.hic_ma.get_chromosome_sizes()
         if chrom_region not in chrom_sizes:
+            chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
+            if chrom_region not in chrom_sizes:
+                self.log.error("*Error*\nNeither " + chrom_region_before + " "
+                               "nor " + chrom_region + " exits as a chromosome"
+                               " name on the matrix.\n")
+                return
 
         chrom_region = self.check_chrom_str_bytes(chrom_sizes, chrom_region)
         if region_end > chrom_sizes[chrom_region]:
@@ -256,9 +262,15 @@ file_type = {}
             formatter = LogFormatter(10, labelOnlyBase=False)
             aa = np.array([1, 2, 5])
             tick_values = np.concatenate([aa * 10 ** x for x in range(10)])
-            cobar = plt.colorbar(self.img, ticks=tick_values, format=formatter, ax=cbar_ax, fraction=0.95)
+            try:
+                cobar = plt.colorbar(self.img, ticks=tick_values, format=formatter, ax=cbar_ax, fraction=0.95)
+            except AttributeError:
+                return
         else:
-            cobar = plt.colorbar(self.img, ax=cbar_ax, fraction=0.95)
+            try:
+                cobar = plt.colorbar(self.img, ax=cbar_ax, fraction=0.95)
+            except AttributeError:
+                return
 
         cobar.solids.set_edgecolor("face")
         cobar.ax.tick_params(labelsize='smaller')

--- a/pygenometracks/tracks/LinksTrack.py
+++ b/pygenometracks/tracks/LinksTrack.py
@@ -115,7 +115,14 @@ file_type = {}
         count = 0
 
         if chrom_region not in list(self.interval_tree):
+            chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
+            if chrom_region not in list(self.interval_tree):
+                self.log.error("*Error*\nNeither " + chrom_region_before + " "
+                               "nor " + chrom_region + " exits as a chromosome"
+                               " name inside the link file.\n")
+                return
+
         chrom_region = self.check_chrom_str_bytes(self.interval_tree, chrom_region)
 
         arcs_in_region = sorted(self.interval_tree[chrom_region][region_start:region_end])

--- a/pygenometracks/tracks/TADsTrack.py
+++ b/pygenometracks/tracks/TADsTrack.py
@@ -17,8 +17,13 @@ class TADsTrack(BedTrack):
             orig = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
             chrom_region = self.check_chrom_str_bytes(self.interval_tree, chrom_region)
-            self.log.info('Chromosome name: {} does not exists. Changing name to {}'.format(orig, chrom_region))
-
+            self.log.info('Chromosome name: {} does not exists. Changing'
+                          ' name to {}'.format(orig, chrom_region))
+            if chrom_region not in self.interval_tree:
+                self.log.error("*Error*\nNeither " + orig + " "
+                               "nor " + chrom_region + " exits as a chromosome"
+                               " name.\n")
+                return
         for region in sorted(self.interval_tree[chrom_region][start_region:end_region]):
             """
                    ______ y2

--- a/pygenometracks/tracksClass.py
+++ b/pygenometracks/tracksClass.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-from __future__ import division
 
 import logging
 from configparser import ConfigParser
-
+from ast import literal_eval
+import time
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
@@ -109,16 +109,11 @@ class PlotTracks(object):
             if 'title' in properties:
                 # adjust titles that are too long
                 # if the track label space is small
+                assert(sys.version_info[0] != 2)
                 if track_label_width < 0.1:
-                    if sys.version_info[0] == 2:
-                        properties['title'] = textwrap.fill(properties['title'].encode("UTF-8"), 12)
-                    else:
-                        properties['title'] = textwrap.fill(properties['title'], 12)
+                    properties['title'] = textwrap.fill(properties['title'], 12)
                 else:
-                    if sys.version_info[0] == 2:
-                        properties['title'] = textwrap.fill(properties['title'].encode("UTF-8"), 30)
-                    else:
-                        properties['title'] = textwrap.fill(properties['title'], 30)
+                    properties['title'] = textwrap.fill(properties['title'], 30)
 
         log.info("time initializing track(s):")
         self.print_elapsed(start)
@@ -305,7 +300,6 @@ class PlotTracks(object):
         :param tracks_file: file path containing the track configuration
         :return: array of dictionaries and vlines_file. One dictionary per track
         """
-        from ast import literal_eval
         parser = ConfigParser(dict_type=MultiDict, strict=False)
         parser.read_file(open(tracks_file, 'r'))
 
@@ -435,7 +429,6 @@ class PlotTracks(object):
 
     @staticmethod
     def print_elapsed(start):
-        import time
         if start:
             log.info(time.time() - start)
         return time.time()

--- a/pygenometracks/utilities.py
+++ b/pygenometracks/utilities.py
@@ -1,4 +1,5 @@
 import sys
+import gzip
 from intervaltree import IntervalTree, Interval
 
 
@@ -9,8 +10,9 @@ def to_string(s):
     if isinstance(s, str):
         return s
     if isinstance(s, bytes):
-        if sys.version_info[0] == 2:
-            return str(s)
+        assert(sys.version_info[0] != 2)
+#        if sys.version_info[0] == 2:
+#            return str(s)
         return s.decode('ascii')
     if isinstance(s, list):
         return [to_string(x) for x in s]
@@ -21,8 +23,9 @@ def to_bytes(s):
     """
     Like toString, but for functions requiring bytes in python3
     """
-    if sys.version_info[0] == 2:
-        return s
+    assert(sys.version_info[0] != 2)
+#    if sys.version_info[0] == 2:
+#        return s
     if isinstance(s, bytes):
         return s
     if isinstance(s, str):
@@ -36,7 +39,6 @@ def opener(filename):
     """
     Determines if a file is compressed or not
     """
-    import gzip
     f = open(filename, 'rb')
     if f.read(2) == b'\x1f\x8b':
         f.seek(0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy >= 1.15
+numpy >= 1.16
 matplotlib
 intervaltree
 pybigwig

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ future
 hicmatrix
 pysam
 pytest
+gffutils

--- a/setup.py
+++ b/setup.py
@@ -97,9 +97,8 @@ install_requires_py = ["numpy >= 1.12.1",
                        "matplotlib >= 2.0.0",
                        "intervaltree >= 2.1.0",
                        "pyBigWig >=0.3.7",
-                       "future >= 0.16.0",
-                       "hicmatrix",
-                       "pysam",
+                       "hicexplorer >= 2.1.1",
+                       "pysam>=0.14",
                        "pytest"
                        ]
 
@@ -124,6 +123,6 @@ setup(
         'Topic :: Scientific/Engineering :: Bio-Informatics'],
     install_requires=install_requires_py,
     zip_safe=False,
-    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4',
+    python_requires='>=3.6.*, <4',
     cmdclass={'sdist': sdist, 'install': install}
 )

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,8 @@ install_requires_py = ["numpy >= 1.12.1",
                        "pyBigWig >=0.3.7",
                        "hicexplorer >= 2.1.1",
                        "pysam>=0.14",
-                       "pytest"
+                       "pytest",
+                       "gffutils" # I do not know which version
                        ]
 
 if sys.version_info[0] == 2 or (sys.version_info[0] == 3 and sys.version_info[1] == 4):


### PR DESCRIPTION
1) Use gtf:
a) I wrote a new class ReadGtf to make an iterator from a gtf file.
b) In BedTrack.py, I added the gtf extension and use ReadGtf if the extension match or if type='gtf' and use ReadBed if not.
c) Added to the requirement gffutils but I do not know if it is useful...
2) Small correction:
I noticed that for bed12 when the thick start = thick end = chrom_start the first exon is plotted as coding and if  start = thick end = chrom_end the last exon is plotted as coding. So I added a condition in both draw_gene_with_introns_flybase_style and draw_gene_with_introns.

What I can do:
add an example,
tell me if you need something else to merge the PR...