### PR TITLE
Making empty tracks if regions are not on the given files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
     install:
     - conda install --yes python=$TRAVIS_PYTHON_VERSION flake8
     script:
-    - if [[ "$LINT" == "1" ]]; then flake8 . --exclude=.venv,.build,build --ignore=E501,F403,E402,F999,F405,E712
+    - if [[ "$LINT" == "1" ]]; then flake8 . --exclude=.venv,.build,build --ignore=E501,F403,E402,F999,F405,E712,W503
       ; fi
 before_install:
 - export TEST_DATA_DIR="`pwd`/pygenometracks/test/test_data/"

--- a/pygenometracks/tests/test_data/master_tracks.ini
+++ b/pygenometracks/tests/test_data/master_tracks.ini
@@ -46,7 +46,7 @@ show_masked_bins = no
 # (only used if you use pdf or svg output format) by using:
 # rasterize = no
 file_type = hic_matrix
-
+    
 [bigwig_chrx_2e6_5e6]
 file=pygenometracks/tests/test_data/bigwig_chrx_2e6_5e6.bw
 
@@ -83,7 +83,7 @@ summary method = mean
 # set show data range to no to hide the text on the upper-left showing the data range
 show data range = yes
 file_type = bigwig
-
+    
 [tad_classification]
 file=pygenometracks/tests/test_data/tad_classification.bed
 
@@ -160,7 +160,7 @@ fontsize = 10
 #global max row = yes
 # optional. If not given is guessed from the file ending.
 file_type = bed
-
+    
 [epilog.qcat]
 file=pygenometracks/tests/test_data/epilog.qcat.bgz
 
@@ -186,3 +186,4 @@ height = 2
 # 	}
 #}
 categories_file = <path to json categories file>
+    

--- a/pygenometracks/tests/test_data/master_tracks.ini
+++ b/pygenometracks/tests/test_data/master_tracks.ini
@@ -46,7 +46,7 @@ show_masked_bins = no
 # (only used if you use pdf or svg output format) by using:
 # rasterize = no
 file_type = hic_matrix
-    
+
 [bigwig_chrx_2e6_5e6]
 file=pygenometracks/tests/test_data/bigwig_chrx_2e6_5e6.bw
 
@@ -83,7 +83,7 @@ summary method = mean
 # set show data range to no to hide the text on the upper-left showing the data range
 show data range = yes
 file_type = bigwig
-    
+
 [tad_classification]
 file=pygenometracks/tests/test_data/tad_classification.bed
 
@@ -160,7 +160,7 @@ fontsize = 10
 #global max row = yes
 # optional. If not given is guessed from the file ending.
 file_type = bed
-    
+
 [epilog.qcat]
 file=pygenometracks/tests/test_data/epilog.qcat.bgz
 
@@ -186,4 +186,3 @@ height = 2
 # 	}
 #}
 categories_file = <path to json categories file>
-    

--- a/pygenometracks/tracks/BedGraphTrack.py
+++ b/pygenometracks/tracks/BedGraphTrack.py
@@ -168,11 +168,11 @@ file_type = {}
                 chrom_region_before = chrom_region
                 chrom_region = self.change_chrom_names(chrom_region)
                 if chrom_region not in list(self.interval_tree):
-                    sys.stderr.write("*Error*\nNeither"
-                                     " " + chrom_region_before + " nor"
-                                     " " + chrom_region + " exits as a "
+                    self.log.warning("*Warning*\nNeither " + chrom_region_before +
+                                     " nor " + chrom_region + " exits as a "
                                      "chromosome name inside the bedgraph "
-                                     "file.\n")
+                                     "file. This will generate an empty "
+                                     "track!!\n")
                     return
             chrom_region = self.check_chrom_str_bytes(self.interval_tree, chrom_region)
             iterator = iter(sorted(self.interval_tree[chrom_region][start_region - 10000:end_region + 10000]))

--- a/pygenometracks/tracks/BedGraphTrack.py
+++ b/pygenometracks/tracks/BedGraphTrack.py
@@ -168,8 +168,9 @@ file_type = {}
                 chrom_region_before = chrom_region
                 chrom_region = self.change_chrom_names(chrom_region)
                 if chrom_region not in list(self.interval_tree):
-                    self.log.warning("*Warning*\nNeither " + chrom_region_before +
-                                     " nor " + chrom_region + " exits as a "
+                    self.log.warning("*Warning*\nNeither "
+                                     + chrom_region_before + " nor "
+                                     + chrom_region + " exits as a "
                                      "chromosome name inside the bedgraph "
                                      "file. This will generate an empty "
                                      "track!!\n")

--- a/pygenometracks/tracks/BedTrack.py
+++ b/pygenometracks/tracks/BedTrack.py
@@ -166,12 +166,12 @@ file_type = {}
             self.colormap = matplotlib.cm.ScalarMappable(norm=norm, cmap=cmap)
 
     def get_length_w(self, fig_width, region_start, region_end):
-        '''
+        """
         to improve the visualization of the genes
         it is good to have an estimation of the label
         length. In the following code I try to get the
         length of a 'W' in base pairs.
-        '''
+        """
         if self.properties['labels'] == 'on':
             # from http://scipy-cookbook.readthedocs.org/items/Matplotlib_LaTeX_Examples.html
             inches_per_pt = 1.0 / 72.27
@@ -300,8 +300,8 @@ file_type = {}
             chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
             if chrom_region not in self.interval_tree.keys():
-                self.log.warning("*Warning*\nNeither " + chrom_region_before +
-                                 " nor " + chrom_region + " exits as a "
+                self.log.warning("*Warning*\nNeither " + chrom_region_before
+                                 + " nor " + chrom_region + " exits as a "
                                  "chromosome name inside the bed file. "
                                  "This will generate an empty track!!\n")
                 return

--- a/pygenometracks/tracks/BedTrack.py
+++ b/pygenometracks/tracks/BedTrack.py
@@ -299,7 +299,6 @@ file_type = {}
         if chrom_region not in self.interval_tree.keys():
             chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
-            print(self.interval_tree.keys())
             if chrom_region not in self.interval_tree.keys():
                 self.log.warning("*Warning*\nNeither " + chrom_region_before +
                                  " nor " + chrom_region + " exits as a "

--- a/pygenometracks/tracks/BedTrack.py
+++ b/pygenometracks/tracks/BedTrack.py
@@ -299,8 +299,12 @@ file_type = {}
         if chrom_region not in self.interval_tree.keys():
             chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
+            print(self.interval_tree.keys())
             if chrom_region not in self.interval_tree.keys():
-                self.log.error("*Error*\nNeither " + chrom_region_before + " nor " + chrom_region + " exits as a chromosome name inside the bed file.\n")
+                self.log.warning("*Warning*\nNeither " + chrom_region_before +
+                                 " nor " + chrom_region + " exits as a "
+                                 "chromosome name inside the bed file. "
+                                 "This will generate an empty track!!\n")
                 return
         chrom_region = self.check_chrom_str_bytes(self.interval_tree,
                                                   chrom_region)

--- a/pygenometracks/tracks/BigWigTrack.py
+++ b/pygenometracks/tracks/BigWigTrack.py
@@ -90,8 +90,8 @@ file_type = {}
             chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
             if chrom_region not in self.bw.chroms().keys():
-                self.log.warning("*Warning*\nNeither " + chrom_region_before +
-                                 " nor " + chrom_region + " exits as a "
+                self.log.warning("*Warning*\nNeither " + chrom_region_before
+                                 + " nor " + chrom_region + " exits as a "
                                  "chromosome name inside the bigwig file. "
                                  "This will generate an empty track!!\n")
                 return

--- a/pygenometracks/tracks/BigWigTrack.py
+++ b/pygenometracks/tracks/BigWigTrack.py
@@ -90,9 +90,10 @@ file_type = {}
             chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
             if chrom_region not in self.bw.chroms().keys():
-                self.log.error("*Error*\nNeither " + chrom_region_before + " "
-                               "nor " + chrom_region + " exits as a chromosome"
-                               " name inside the bigwig file.\n")
+                self.log.warning("*Warning*\nNeither " + chrom_region_before +
+                                 " nor " + chrom_region + " exits as a "
+                                 "chromosome name inside the bigwig file. "
+                                 "This will generate an empty track!!\n")
                 return
 
         chrom_region = self.check_chrom_str_bytes(self.bw.chroms().keys(), chrom_region)

--- a/pygenometracks/tracks/HiCMatrixTrack.py
+++ b/pygenometracks/tracks/HiCMatrixTrack.py
@@ -158,8 +158,8 @@ file_type = {}
             chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
             if chrom_region not in chrom_sizes:
-                self.log.warning("*Warning*\nNeither " + chrom_region_before +
-                                 " nor " + chrom_region + " exits as a "
+                self.log.warning("*Warning*\nNeither " + chrom_region_before
+                                 + " nor " + chrom_region + " exits as a "
                                  "chromosome name on the matrix. "
                                  "This will generate an empty track!!\n")
                 return

--- a/pygenometracks/tracks/HiCMatrixTrack.py
+++ b/pygenometracks/tracks/HiCMatrixTrack.py
@@ -158,9 +158,10 @@ file_type = {}
             chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
             if chrom_region not in chrom_sizes:
-                self.log.error("*Error*\nNeither " + chrom_region_before + " "
-                               "nor " + chrom_region + " exits as a chromosome"
-                               " name on the matrix.\n")
+                self.log.warning("*Warning*\nNeither " + chrom_region_before +
+                                 " nor " + chrom_region + " exits as a "
+                                 "chromosome name on the matrix. "
+                                 "This will generate an empty track!!\n")
                 return
 
         chrom_region = self.check_chrom_str_bytes(chrom_sizes, chrom_region)

--- a/pygenometracks/tracks/LinksTrack.py
+++ b/pygenometracks/tracks/LinksTrack.py
@@ -186,9 +186,10 @@ file_type = {}
             chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
             if chrom_region not in list(self.interval_tree):
-                self.log.error("*Error*\nNeither " + chrom_region_before + " "
-                               "nor " + chrom_region + " exits as a chromosome"
-                               " name inside the link file.\n")
+                self.log.warning("*Warning*\nNeither " + chrom_region_before +
+                                 " nor " + chrom_region + " exits as a "
+                                 "chromosome name inside the link file. "
+                                 "This will generate an empty track!!\n")
                 return
 
         chrom_region = self.check_chrom_str_bytes(self.interval_tree, chrom_region)

--- a/pygenometracks/tracks/LinksTrack.py
+++ b/pygenometracks/tracks/LinksTrack.py
@@ -186,8 +186,8 @@ file_type = {}
             chrom_region_before = chrom_region
             chrom_region = self.change_chrom_names(chrom_region)
             if chrom_region not in list(self.interval_tree):
-                self.log.warning("*Warning*\nNeither " + chrom_region_before +
-                                 " nor " + chrom_region + " exits as a "
+                self.log.warning("*Warning*\nNeither " + chrom_region_before
+                                 + " nor " + chrom_region + " exits as a "
                                  "chromosome name inside the link file. "
                                  "This will generate an empty track!!\n")
                 return


### PR DESCRIPTION
If the given files in the .ini don't have the regions which have been asked via --region or --BED , it generates an empty track. This has been implemented as a response to #120  