### PR TITLE
solve a warning of matplotlib

### DIFF
--- a/pygenometracks/tracksClass.py
+++ b/pygenometracks/tracksClass.py
@@ -251,12 +251,12 @@ class PlotTracks(object):
                 plot_axis.axis[:].set_visible(False)
                 # to make the background transparent
                 plot_axis.patch.set_visible(False)
+                if not overlay:
+                    y_axis = plt.subplot(grids[idx, 0])
+                    y_axis.set_axis_off()
 
-                y_axis = plt.subplot(grids[idx, 0])
-                y_axis.set_axis_off()
-
-                label_axis = plt.subplot(grids[idx, 2])
-                label_axis.set_axis_off()
+                    label_axis = plt.subplot(grids[idx, 2])
+                    label_axis.set_axis_off()
 
             plot_axis.set_xlim(start, end)
             track.plot(plot_axis, chrom, start, end)


### PR DESCRIPTION
Hi,
When you use overlay=yes. You get:
```
/home/ldelisle/.conda/envs/pygenometracks_develop/lib/python3.6/site-packages/pygenometracks/tracksClass.py:255: MatplotlibDeprecationWarning: Adding an axes using the same arguments as a previous axes currently reuses the earlier instance.  In a future version, a new instance will always be created and returned.  Meanwhile, this warning can be suppressed, and the future behavior ensured, by passing a unique label to each axes instance.
    y_axis = plt.subplot(grids[idx, 0])

/home/ldelisle/.conda/envs/pygenometracks_develop/lib/python3.6/site-packages/pygenometracks/tracksClass.py:258: MatplotlibDeprecationWarning: Adding an axes using the same arguments as a previous axes currently reuses the earlier instance.  In a future version, a new instance will always be created and returned.  Meanwhile, this warning can be suppressed, and the future behavior ensured, by passing a unique label to each axes instance.
    label_axis = plt.subplot(grids[idx, 2])
```
This PR solve this issue.