### PR TITLE
fixed cases with no data in qcat file

### DIFF
--- a/pygenometracks/tracks/EpilogosTrack.py
+++ b/pygenometracks/tracks/EpilogosTrack.py
@@ -93,7 +93,6 @@ file_type = {}
             if not isinstance(qcat_json, str):
                 # This would happen if the qcat file has a missing value.
                 # The missing value is filled with np.repeat(np.nan, ..) and should be skipped here.
-                # The hole will be fill with np.repeat(np.nan, ..)
                 continue
             qcat_json = '{' + qcat_json.replace('id', '"id"').replace('qcat', '"qcat"') + '}'
             qcat = json.loads(qcat_json)

--- a/pygenometracks/tracks/EpilogosTrack.py
+++ b/pygenometracks/tracks/EpilogosTrack.py
@@ -90,6 +90,10 @@ file_type = {}
             # the qcat_json is a pseudo json line, that misses
             # the { } and the quotes. The following lines fix that.
             qcat_json = qcat_json[0]
+            if not isinstance(qcat_json, str):
+                # This would happen if the qcat file has a hole.
+                # The hole will be fill with np.repeat(np.nan, ..)
+                continue
             qcat_json = '{' + qcat_json.replace('id', '"id"').replace('qcat', '"qcat"') + '}'
             qcat = json.loads(qcat_json)
 

--- a/pygenometracks/tracks/EpilogosTrack.py
+++ b/pygenometracks/tracks/EpilogosTrack.py
@@ -91,7 +91,8 @@ file_type = {}
             # the { } and the quotes. The following lines fix that.
             qcat_json = qcat_json[0]
             if not isinstance(qcat_json, str):
-                # This would happen if the qcat file has a hole.
+                # This would happen if the qcat file has a missing value.
+                # The missing value is filled with np.repeat(np.nan, ..) and should be skipped here.
                 # The hole will be fill with np.repeat(np.nan, ..)
                 continue
             qcat_json = '{' + qcat_json.replace('id', '"id"').replace('qcat', '"qcat"') + '}'


### PR DESCRIPTION
Relative to #51 
Maybe I need to change the formulation. A hole means a region with no corresponding line in the qcat file.