### PR TITLE
added alpha to the FLOAT_PROPERTIES in Links

### DIFF
--- a/pygenometracks/tracks/LinksTrack.py
+++ b/pygenometracks/tracks/LinksTrack.py
@@ -64,6 +64,7 @@ file_type = {}
                          'title', 'color']
     FLOAT_PROPERTIES = {'max_value': [- np.inf, np.inf],
                         'min_value': [- np.inf, np.inf],
+                        'alpha': [0, 1],
                         'line_width': [0, np.inf],
                         'height': [0, np.inf]}
     INTEGER_PROPERTIES = {}


### PR DESCRIPTION
Solve a small bug: alpha cannot be used in links tracks because I forgot to add it to FLOAT_PROPERTIES.