### PR TITLE
only accept chr:start-end as region input

### DIFF
--- a/pygenometracks/plotTracks.py
+++ b/pygenometracks/plotTracks.py
@@ -150,7 +150,6 @@ from pygenometracks._version import __version__
 from .utilities import InputError
 
 DEFAULT_FIGURE_WIDTH = 40  # in centimeters
-HUGE_NUMBER = 1e15  # Which should be above any chromosome size
 
 
 def parse_arguments(args=None):
@@ -247,29 +246,38 @@ def get_region(region_string):
         try:
             chrom, position = region_string.strip().split(":")
         except ValueError:
-            # It can be a full chromosome:
-            return region_string.strip(), 0, HUGE_NUMBER
+            raise InputError(f"The region provided ({region_string})"
+                             " is not valid, it should be chr:start-end.\n")
 
         # clean up the position
         for char in ",.;|!{}()":
             position = position.replace(char, '')
 
         position_list = position.split("-")
+        assert len(position_list) == 2, \
+            f"The region provided ({region_string})" \
+            " is not valid, it should be chr:start-end.\n"
+
         try:
             region_start = int(position_list[0])
-        except IndexError:
-            region_start = 0
+        except ValueError:
+            raise InputError(f"The start value ({position_list[0]}) in the"
+                             " region provided"
+                             " is not valid, it should be chr:start-end.\n")
         try:
             region_end = int(position_list[1])
-        except IndexError:
-            region_end = HUGE_NUMBER
-        if region_start < 0:
-            region_start = 0
+        except ValueError:
+            raise InputError(f"The start value ({position_list[0]}) in the"
+                             " region provided"
+                             " is not valid, it should be chr:start-end.\n")
+
         if region_end <= region_start:
             raise InputError("Please check that the region end is larger "
                              "than the region start.\n"
                              f"Values given:\nstart: {region_start}\n"
-                             f"end: {region_end}\n")
+                             f"end: {region_end}\n"
+                             "To plot tracks with a decreasing axis "
+                             "consider using `--decreasingXAxis`.")
 
         return chrom, region_start, region_end
 

--- a/pygenometracks/tests/test_checker.py
+++ b/pygenometracks/tests/test_checker.py
@@ -299,3 +299,85 @@ class TestCheckerMethods(unittest.TestCase):
             pygenometracks.plotTracks.main(args)
 
         assert("can not identify file type" in str(context.exception))
+
+
+class TestInputRegionMethods(unittest.TestCase):
+
+    def test_region_format_onlychr(self):
+        """
+        This test check that you get an error
+        if the region format is not good
+        """
+        outfile_name = "test.png"
+        ini_file = os.path.join(ROOT, "empty.ini")
+        region = "X"
+        args = f"--tracks {ini_file} --region {region} "\
+            f"--outFileName {outfile_name}".split()
+        with self.assertRaises(InputError) as context:
+            pygenometracks.plotTracks.main(args)
+
+        assert("is not valid, it should be chr:start-end" in
+               str(context.exception))
+
+    def test_region_format_chr_only_start(self):
+        """
+        This test check that you get an error
+        if the region format is not good
+        """
+        outfile_name = "test.png"
+        ini_file = os.path.join(ROOT, "empty.ini")
+        region = "X:12"
+        args = f"--tracks {ini_file} --region {region} "\
+            f"--outFileName {outfile_name}".split()
+        with self.assertRaises(Exception) as context:
+            pygenometracks.plotTracks.main(args)
+
+        assert("is not valid, it should be chr:start-end" in
+               str(context.exception))
+
+    def test_region_format_invalid_start(self):
+        """
+        This test check that you get an error
+        if the region format is not good
+        """
+        outfile_name = "test.png"
+        ini_file = os.path.join(ROOT, "empty.ini")
+        for region in ['X:a-12', 'X:-3']:
+            args = f"--tracks {ini_file} --region {region} "\
+                   f"--outFileName {outfile_name}".split()
+            with self.assertRaises(InputError) as context:
+                pygenometracks.plotTracks.main(args)
+
+            assert("is not valid, it should be chr:start-end" in
+                   str(context.exception))
+
+    def test_region_format_invalid_end(self):
+        """
+        This test check that you get an error
+        if the region format is not good
+        """
+        outfile_name = "test.png"
+        ini_file = os.path.join(ROOT, "empty.ini")
+        region = "X:12-1d"
+        args = f"--tracks {ini_file} --region {region} "\
+            f"--outFileName {outfile_name}".split()
+        with self.assertRaises(InputError) as context:
+            pygenometracks.plotTracks.main(args)
+
+        assert("is not valid, it should be chr:start-end" in
+               str(context.exception))
+
+    def test_region_format_start_smaller_end(self):
+        """
+        This test check that you get an error
+        if the region format is not good
+        """
+        outfile_name = "test.png"
+        ini_file = os.path.join(ROOT, "empty.ini")
+        region = "X:12-1"
+        args = f"--tracks {ini_file} --region {region} "\
+            f"--outFileName {outfile_name}".split()
+        with self.assertRaises(InputError) as context:
+            pygenometracks.plotTracks.main(args)
+
+        assert("end is larger" in str(context.exception))


### PR DESCRIPTION
I realized it was not useful to plot on a whole chromosome when we don't know the size of it so I decided to be more stringent on the region provided by the user.