### PR TITLE
Solve some bugs

### DIFF
--- a/pygenometracks/readBed.py
+++ b/pygenometracks/readBed.py
@@ -104,7 +104,7 @@ class ReadBed(object):
         >>> bed.chromosome
         'chr1'
         >>> bed.block_starts
-        [20, 200, 700]
+        [0, 200, 700]
 
         >>> bed_line="chr2\t0\t1000\tgene_1\t0.5\t-\n"
         >>> with open('/tmp/test.bed', 'w') as fh:

--- a/pygenometracks/readBed.py
+++ b/pygenometracks/readBed.py
@@ -96,7 +96,7 @@ class ReadBed(object):
         Processes each bed line from a bed file, casts the values and returns
         a namedtuple object
 
-        >>> bed_line="chr1\t0\t1000\tgene_1\t0.5\t-\t0\t1000\t0\t3\t10,20,100\t20,200,700"
+        >>> bed_line="chr1\t0\t1000\tgene_1\t0.5\t-\t0\t1000\t0\t3\t10,20,300\t0,200,700"
         >>> with open('/tmp/test.bed', 'w') as fh:
         ...     foo = fh.write(bed_line)
         >>> bed_f = ReadBed(open('/tmp/test.bed','r'))

--- a/pygenometracks/readBed.py
+++ b/pygenometracks/readBed.py
@@ -270,7 +270,7 @@ class ReadBed(object):
                                          f"#{self.line_number}, "
                                          f"the block field {r} is not "
                                          f"valid.\nError message: {detail}"
-                                         "\nNo block will be used.\n")
+                                         "\nOne block will be used.\n")
                         line_values = line_values[:9]
                         line_values.append(1)
                         line_values.append([line_values[2] - line_values[1]])
@@ -359,3 +359,11 @@ def check_bed12(line_values, line_number, bed_line):
             " 12th field of a bed12 should contains relative start" \
             " positions of blocks and the 11th field should contains" \
             " the length of each block."
+    assert min(block_relative_starts) == 0, \
+        f"The blocks relative_starts of line\n{bed_line}\n" \
+        "does not contain 0. BED blocks must span chromStart" \
+        " to chromEnd."
+    assert max([bstart + bsize for bstart, bsize in zip(block_relative_starts, block_sizes)]) == line_values[2] - line_values[1], \
+        f"The blocks described in line\n{bed_line}\n" \
+        "does not cover chromEnd. BED blocks must span chromStart" \
+        " to chromEnd."

--- a/pygenometracks/tracks/GenomeTrack.py
+++ b/pygenometracks/tracks/GenomeTrack.py
@@ -299,10 +299,10 @@ height = 2
         elif self.properties[param][0] == '(':
             try:
                 custom_color = eval(self.properties[param])
-            except ValueError:
+            except (SyntaxError, NameError) as e:
                 self.log.warning(f"*WARNING*: '{param}' for section"
                                  f" {self.properties[param]}"
-                                 " is not valid. "
+                                 f" raised an error:\n{e}\n"
                                  f"{self.properties['section_name']} has "
                                  "been set to "
                                  f"{default_value}.\n")

--- a/pygenometracks/tracks/ScaleBarTrack.py
+++ b/pygenometracks/tracks/ScaleBarTrack.py
@@ -56,9 +56,12 @@ file_type = {TRACK_TYPE}
     # The color can only be a color
 
     def plot(self, ax, chrom_region, start_region, end_region):
+        # Get the center from the properties
         x_center = self.properties['x_center']
         if x_center is None:
+            # Else put it in the middle
             x_center = (end_region + start_region) / 2
+        # Get the size form the properties
         size = self.properties['size']
         if size is None:
             # We put the size that is less than half the plotted region
@@ -72,6 +75,11 @@ file_type = {TRACK_TYPE}
             else:
                 first_char = 1
             size = first_char * 10**(len(str(half_plotted_region)) - 1)
+        # We only plot if it will be visible
+        if x_center - size / 2 > end_region or x_center + size / 2 < start_region:
+            return
+
+        # We adjust the unit to make it pretty
         if size < 1e3:
             size_label = f"{size} bases"
         elif size < 1e6:

--- a/pygenometracks/tracksClass.py
+++ b/pygenometracks/tracksClass.py
@@ -357,7 +357,13 @@ class PlotTracks(object):
                                      " but there is no file.")
                 track_options['file'] = parser.get(section_name, 'file')
                 if 'line_width' in all_keywords:
-                    track_options['line_width'] = parser.get(section_name, 'line_width')
+                    try:
+                        track_options['line_width'] = float(parser.get(section_name, 'line_width'))
+                    except ValueError:
+                        raise InputError(f"In section {section_name}, line_width "
+                                         f"was set to {parser.get(section_name, 'line_width')}"
+                                         " whereas we should have a float "
+                                         "value.")
                 extra_keywords = [k for k in all_keywords
                                   if k not in ['file', 'type', 'line_width']]
                 if len(extra_keywords) > 0:

--- a/pygenometracks/tracksClass.py
+++ b/pygenometracks/tracksClass.py
@@ -359,7 +359,7 @@ class PlotTracks(object):
                 if 'line_width' in all_keywords:
                     track_options['line_width'] = parser.get(section_name, 'line_width')
                 extra_keywords = [k for k in all_keywords
-                                    if k not in ['file', 'type', 'line_width']]
+                                  if k not in ['file', 'type', 'line_width']]
                 if len(extra_keywords) > 0:
                     log.warn("These parameters were specified but will not"
                              f" be used {' '.join(extra_keywords)}.\n")

--- a/pygenometracks/tracksClass.py
+++ b/pygenometracks/tracksClass.py
@@ -630,7 +630,7 @@ class SpacerTrack(GenomeTrack):
     POSSIBLE_PROPERTIES = {}
     BOOLEAN_PROPERTIES = []
     STRING_PROPERTIES = ['overlay_previous',
-                         'title']
+                         'title', 'file_type']
     FLOAT_PROPERTIES = {'height': [0, np.inf]}
     INTEGER_PROPERTIES = {}
 
@@ -651,7 +651,7 @@ class XAxisTrack(GenomeTrack):
     POSSIBLE_PROPERTIES = {'where': ['top', 'bottom']}
     BOOLEAN_PROPERTIES = []
     STRING_PROPERTIES = ['overlay_previous',
-                         'title', 'where']
+                         'title', 'where', 'file_type']
     FLOAT_PROPERTIES = {'fontsize': [0, np.inf],
                         'height': [0, np.inf]}
     INTEGER_PROPERTIES = {}

--- a/pygenometracks/tracksClass.py
+++ b/pygenometracks/tracksClass.py
@@ -356,9 +356,11 @@ class PlotTracks(object):
                     raise InputError(f"The section {section_name} is supposed to be a vline"
                                      " but there is no file.")
                 track_options['file'] = parser.get(section_name, 'file')
-                if len(all_keywords) > 2:
-                    extra_keywords = [k for k in all_keywords
-                                      if k not in ['file', 'type']]
+                if 'line_width' in all_keywords:
+                    track_options['line_width'] = parser.get(section_name, 'line_width')
+                extra_keywords = [k for k in all_keywords
+                                    if k not in ['file', 'type', 'line_width']]
+                if len(extra_keywords) > 0:
                     log.warn("These parameters were specified but will not"
                              f" be used {' '.join(extra_keywords)}.\n")
                 self.vlines_properties = \

--- a/pygenometracks/utilities.py
+++ b/pygenometracks/utilities.py
@@ -261,7 +261,7 @@ def transform(score_list, transform, log_pseudocount, file):
         else:
             return(np.log1p(score_list))
     elif transform == '-log':
-        if np.nanmax(score_list) <= - log_pseudocount:
+        if np.nanmin(score_list) <= - log_pseudocount:
             msg = ("\n*ERROR*\ncoverage contains values smaller or equal to"
                    f" - {log_pseudocount}.\n"
                    f"- log( {log_pseudocount} + <values>) transformation can "


### PR DESCRIPTION
Major:
- line_width for vlines was ignored
- in coverage when using -log was not tested correctly for potential log of negative values

Minor:
- better error handling with custom color
- more stringent on bed12 (like in UCSC)
- do not show a warning when using `file_type = x_axis`
- only plot scale bar when in the region
