### PR TITLE
Add new track type for GWAS summary statistics/variants

### DIFF
--- a/pygenometracks/makeTracksFile.py
+++ b/pygenometracks/makeTracksFile.py
@@ -9,8 +9,9 @@ from pygenometracks._version import __version__
 def parse_arguments(args=None):
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-                                     description='Facilitates the creation of a configuration file for pyGenomeTracks. The program takes a list '
-                                                 'of files and does the boilerplate for the configuration file.',
+                                     description='Facilitates the creation of a configuration file for '
+                                                 'pyGenomeTracks. The program takes a list of files and does the '
+                                                 'boilerplate for the configuration file.',
                                      usage="%(prog)s --trackFiles <bigwig file> <bed file> etc. -o tracks.ini")
 
     # define the arguments

--- a/pygenometracks/makeTracksFile.py
+++ b/pygenometracks/makeTracksFile.py
@@ -8,8 +8,9 @@ from pygenometracks.tracksClass import PlotTracks
 def parse_arguments(args=None):
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-                                     description='Facilitates the creation of a configuration file for pyGenomeTracks. The program takes a list '
-                                                 'of files and does the boilerplate for the configuration file.',
+                                     description='Facilitates the creation of a configuration file for '
+                                                 'pyGenomeTracks. The program takes a list of files and does the '
+                                                 'boilerplate for the configuration file.',
                                      usage="%(prog)s --trackFiles <bigwig file> <bed file> etc. -o tracks.ini")
 
     # define the arguments

--- a/pygenometracks/plotTracks.py
+++ b/pygenometracks/plotTracks.py
@@ -247,7 +247,11 @@ def parse_arguments(args=None):
 
 
 def main(args=None):
+    """
+    Main function to plot the tracks.
 
+    :param args: arguments to parse. Default is None.
+    """
     args = parse_arguments().parse_args(args)
 
     # Identify the regions to plot:
@@ -276,7 +280,7 @@ def main(args=None):
                      track_label_width=args.trackLabelFraction,
                      plot_regions=regions, plot_width=args.plotWidth)
 
-    # Create dir if dir does not exists:
+    # Create dir if dir does not exist:
     # Modified from https://stackoverflow.com/questions/12517451/automatically-creating-directories-with-file-output
     os.makedirs(os.path.dirname(os.path.abspath(args.outFileName)), exist_ok=True)
 

--- a/pygenometracks/plotTracks.py
+++ b/pygenometracks/plotTracks.py
@@ -292,9 +292,8 @@ def main(args=None):
         for chrom, start, end in regions:
             file_name = f"{file_prefix}_{chrom}-{start}-{end}.{file_suffix}"
             if end - start < 200000:
-                warnings.warn("A region shorter than 200kb has been "
-                              "detected! This can be too small to return "
-                              "a proper TAD plot!\n")
+                warnings.warn("A region shorter than 200kb has been detected! This can be too small to return a proper "
+                              "TAD plot!\n")
             sys.stderr.write(f"saving {file_name}\n")
             current_fig = trp.plot(file_name, chrom, start, end, title=args.title,
                                    h_align_titles=args.trackLabelHAlign,

--- a/pygenometracks/plotTracks.py
+++ b/pygenometracks/plotTracks.py
@@ -293,9 +293,8 @@ def main(args=None):
         for chrom, start, end in regions:
             file_name = f"{file_prefix}_{chrom}-{start}-{end}.{file_suffix}"
             if end - start < 200000:
-                warnings.warn("A region shorter than 200kb has been "
-                              "detected! This can be too small to return "
-                              "a proper TAD plot!\n")
+                warnings.warn("A region shorter than 200kb has been detected! This can be too small to return a proper "
+                              "TAD plot!\n")
             sys.stderr.write(f"saving {file_name}\n")
             current_fig = trp.plot(file_name, chrom, start, end, title=args.title,
                                    h_align_titles=args.trackLabelHAlign,

--- a/pygenometracks/plotTracks.py
+++ b/pygenometracks/plotTracks.py
@@ -248,7 +248,11 @@ def parse_arguments(args=None):
 
 
 def main(args=None):
+    """
+    Main function to plot the tracks.
 
+    :param args: arguments to parse. Default is None.
+    """
     args = parse_arguments().parse_args(args)
 
     # Identify the regions to plot:
@@ -277,7 +281,7 @@ def main(args=None):
                      track_label_width=args.trackLabelFraction,
                      plot_regions=regions, plot_width=args.plotWidth)
 
-    # Create dir if dir does not exists:
+    # Create dir if dir does not exist:
     # Modified from https://stackoverflow.com/questions/12517451/automatically-creating-directories-with-file-output
     os.makedirs(os.path.dirname(os.path.abspath(args.outFileName)), exist_ok=True)
 

--- a/pygenometracks/readGtf.py
+++ b/pygenometracks/readGtf.py
@@ -42,8 +42,7 @@ class ReadGtf(object):
 
     """
 
-    def __init__(self, file_path, prefered_name="transcript_name",
-                 merge_transcripts=True,
+    def __init__(self, file_path, prefered_name="transcript_name", merge_transcripts=True,
                  merge_overlapping_exons=True):
         """
         :param file_path: the path of the gtf file
@@ -53,11 +52,8 @@ class ReadGtf(object):
         self.file_type = 'bed12'
 
         # list of bed fields
-        self.fields = ['chromosome', 'start', 'end',
-                       'name', 'score', 'strand',
-                       'thick_start', 'thick_end',
-                       'rgb', 'block_count',
-                       'block_sizes', 'block_starts']
+        self.fields = ['chromosome', 'start', 'end', 'name', 'score', 'strand', 'thick_start', 'thick_end', 'rgb',
+                       'block_count', 'block_sizes', 'block_starts']
 
         self.BedInterval = collections.namedtuple('BedInterval', self.fields)
         # I think the name which should be written
@@ -83,15 +79,13 @@ class ReadGtf(object):
         else:
             if self.merge_transcripts:
                 self.length = self.db.count_features_of_type("gene")
-                self.all_transcripts = self.db.features_of_type("gene",
-                                                                order_by='start')
+                self.all_transcripts = self.db.features_of_type("gene", order_by='start')
             else:
                 self.length = self.db.count_features_of_type("transcript")
                 if self.length == 0:
                     # This is unexpected as the database contains things
                     log.warning("No transcript found consider. If your gtf only have genes, use `merge_transcripts = true`")
-                self.all_transcripts = self.db.features_of_type("transcript",
-                                                                order_by='start')
+                self.all_transcripts = self.db.features_of_type("transcript", order_by='start')
 
     def __iter__(self):
         return self
@@ -106,43 +100,34 @@ class ReadGtf(object):
 
     def get_bed_interval(self):
         """
-        Process a transcript from the database,
-        retrieve all the values and return
-        a namedtuple object
+        Process a transcript from the database, retrieve all the values and return a namedtuple object.
         """
         tr = next(self.all_transcripts)
+
         # The name would be the prefered_name if exists
         try:
             trName = tr.attributes[self.prefered_name][0]
         except KeyError:
             # Else try to guess the prefered_name from exons:
             try:
-                trName = set([e.attributes[self.prefered_name][0]
-                              for e in
-                              self.db.children(tr,
-                                               featuretype='exon',
-                                               order_by='start')]).pop()
+                trName = set(
+                    [e.attributes[self.prefered_name][0] for e in self.db.children(tr, featuretype='exon', order_by='start')]
+                ).pop()
             except KeyError:
                 # Else take the transcript id
                 trName = tr.id
-        # If the cds is defined in the gtf,
-        # use it to define the thick start and end
-        # The gtf is 1-based closed intervalls
-        # and bed are 0-based half-open so:
-        # I need to remove one from each start
+
+        # If the cds is defined in the gtf, use it to define the thick start and end. The gtf is 1-based closed
+        # intervals and bed are 0-based half-open so: I need to remove one from each start
         try:
-            cds_start = next(self.db.children(tr,
-                                              featuretype='CDS',
-                                              order_by='start')).start - 1
-            cds_end = next(self.db.children(tr,
-                                            featuretype='CDS',
-                                            order_by='-start')).end
+            cds_start = next(self.db.children(tr, featuretype='CDS', order_by='start')).start - 1
+            cds_end = next(self.db.children(tr, featuretype='CDS', order_by='-start')).end
         except StopIteration:
-            # If the CDS is not defined, then it is set to the start
-            # as proposed here:
+            # If the CDS is not defined, then it is set to the start as proposed here:
             # https://genome.ucsc.edu/FAQ/FAQformat.html#format1
             cds_start = tr.start - 1
             cds_end = tr.start - 1
+
         # Get all exons starts and end to get lengths
         exons = [e for e in self.db.children(tr, featuretype='exon', order_by='start')]
         if len(exons) > 0:
@@ -158,44 +143,32 @@ class ReadGtf(object):
                         current_end = e.end
                     else:
                         if e.start > current_end:
-                            # This is a non-overlapping exon
-                            # We store the previous exon:
+                            # This is a non-overlapping exon. We store the previous exon:
                             exons_starts.append(current_start)
                             exons_ends.append(current_end)
                             # We set the current:
                             current_start = e.start - 1
                             current_end = e.end
                         else:
-                            # This is an overlapping exon
-                            # We update current_end if necessary
+                            # This is an overlapping exon. We update current_end if necessary
                             current_end = max(current_end, e.end)
                 if current_start != -1:
                     # There is a last exon to store:
                     exons_starts.append(current_start)
                     exons_ends.append(current_end)
             else:
-                exons_starts = [e.start - 1
-                                for e in
-                                exons]
-                exons_ends = [e.end
-                              for e in
-                              exons]
+                exons_starts = [e.start - 1 for e in exons]
+                exons_ends = [e.end for e in exons]
         else:
             # This means that the gtf does not have exon info for this gene/transcript:
             try:
-                exons_starts = [[ch.start - 1
-                                 for ch in self.db.children(tr,
-                                                            order_by='start')][0]]
-                exons_ends = [[ch.end
-                               for ch in self.db.children(tr,
-                                                          order_by='end',
-                                                          reverse=True)][0]]
+                exons_starts = [[ch.start - 1 for ch in self.db.children(tr, order_by='start')][0]]
+                exons_ends = [[ch.end for ch in self.db.children(tr, order_by='end', reverse=True)][0]]
             except IndexError:
                 exons_starts = [tr.start - 1]
                 exons_ends = [tr.end]
         exons_length = [e - s for s, e in zip(exons_starts, exons_ends)]
         relative_exons_starts = [s - (tr.start - 1) for s in exons_starts]
-        line_values = [tr.chrom, tr.start - 1, tr.end, trName, 0, tr.strand,
-                       cds_start, cds_end, "0", len(exons_starts),
+        line_values = [tr.chrom, tr.start - 1, tr.end, trName, 0, tr.strand, cds_start, cds_end, "0", len(exons_starts),
                        exons_length, relative_exons_starts]
         return self.BedInterval._make(line_values)

--- a/pygenometracks/setup.py
+++ b/pygenometracks/setup.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import subprocess
+import re
+
+from setuptools import setup, find_packages
+from setuptools.command.sdist import sdist as _sdist
+from setuptools.command.install import install as _install
+
+VERSION_PY = """
+# This file is originally generated from Git information by running 'setup.py
+# version'. Distribution tarballs contain a pre-generated copy of this file.
+
+__version__ = '%s'
+"""
+
+
+def update_version_py():
+    if not os.path.isdir(".git"):
+        print("This does not appear to be a Git repository.")
+        return
+    try:
+        p = subprocess.Popen(["git", "describe",
+                              "--tags", "--always"],
+                             stdout=subprocess.PIPE)
+    except EnvironmentError:
+        print("unable to run git, leaving pygenometracks/_version.py alone")
+        return
+    stdout = p.communicate()[0]
+    if p.returncode != 0:
+        print("unable to run git, leaving pygenometracks/_version.py alone")
+        return
+    ver = stdout.strip()
+    f = open(os.path.join("pygenometracks", "_version.py"), "w")
+    f.write(VERSION_PY % ver)
+    f.close()
+    print(f"set pygenometracks/_version.py to '{ver}'")
+
+
+def get_version():
+    try:
+        f = open(os.path.join("pygenometracks", "_version.py"))
+    except EnvironmentError:
+        return None
+    for line in f.readlines():
+        mo = re.match("__version__ = '([^']+)'", line)
+        if mo:
+            ver = mo.group(1)
+            return ver
+    return None
+
+
+class sdist(_sdist):
+
+    def run(self):
+        # update_version_py()
+        self.distribution.metadata.version = get_version()
+        return _sdist.run(self)
+
+# Install class to check for external dependencies from OS environment
+
+
+class install(_install):
+
+    def run(self):
+        # update_version_py()
+        self.distribution.metadata.version = get_version()
+        _install.run(self)
+        return
+
+    def checkProgramIsInstalled(self, program, args, where_to_download,
+                                affected_tools):
+        try:
+            subprocess.Popen([program, args],
+                             stderr=subprocess.PIPE,
+                             stdout=subprocess.PIPE)
+            return True
+        except EnvironmentError:
+            # handle file not found error.
+            # the config file is installed in:
+            msg = (f"\n**{program} not found. This program is needed"
+                   " for the following tools to work properly:\n"
+                   f"{affected_tools}\n{program} can be downloaded"
+                   f" from here:\n{where_to_download}\n")
+            sys.stderr.write(msg)
+
+        except Exception as e:
+            sys.stderr.write(f"Error: {e}")
+
+
+install_requires_py = ["numpy >=1.20",
+                       "matplotlib >=3.1.1,<=3.6.2",
+                       "intervaltree >=2.1.0",
+                       "pyBigWig >=0.3.16",
+                       "future >=0.17.0",
+                       "hicmatrix >=15",
+                       "pysam >=0.14",
+                       "pytest",
+                       "gffutils >=0.9",
+                       "pybedtools >=0.8.1",
+                       "tqdm >=4.20",
+                       "bx-python >=0.8.13",
+                       "pyfaidx >=0.1.3"
+                       ]
+
+setup(
+    name='pyGenomeTracks',
+    version=get_version(),
+    author='Lucille Lopez-Delisle, Leily Rabbani, Joachim Wolf, Björn Grüning',
+    packages=find_packages(exclude=['tests']),
+    scripts=['bin/make_tracks_file', 'bin/pgt', 'bin/pyGenomeTracks'],
+    include_package_data=True,
+    package_dir={'pygenometracks': 'pygenometracks'},
+    url='http://pygenometracks.readthedocs.io',
+    license='LICENSE.txt',
+    description='Command-line tool to make beautiful and reproducible genome browser snapshots',
+    long_description=open('README.md').read().replace("./docs/", "https://raw.githubusercontent.com/deeptools/pyGenomeTracks/" + get_version() + "/docs/"),
+    long_description_content_type="text/markdown",
+    classifiers=[
+        'Intended Audience :: Science/Research',
+        'Topic :: Scientific/Engineering :: Bio-Informatics'],
+    install_requires=install_requires_py,
+    zip_safe=False,
+    python_requires='>=3.7, <4',
+    cmdclass={'sdist': sdist, 'install': install}
+)

--- a/pygenometracks/tests/test_gwasTrack.py
+++ b/pygenometracks/tests/test_gwasTrack.py
@@ -1,0 +1,14 @@
+import matplotlib as mpl
+from matplotlib.testing.compare import compare_images
+from tempfile import NamedTemporaryFile
+import os.path
+import pygenometracks.plotTracks
+mpl.use('agg')
+
+ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                    "test_data")
+
+browser_tracks = """
+[x-axis]
+"""
+# TODO: this is incomplete?

--- a/pygenometracks/tests/test_gwasTrack.py
+++ b/pygenometracks/tests/test_gwasTrack.py
@@ -1,0 +1,13 @@
+import matplotlib as mpl
+from matplotlib.testing.compare import compare_images
+from tempfile import NamedTemporaryFile
+import os.path
+import pygenometracks.plotTracks
+mpl.use('agg')
+
+ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                    "test_data")
+
+browser_tracks = """
+[x-axis]
+"""

--- a/pygenometracks/tracks/BedTrack.py
+++ b/pygenometracks/tracks/BedTrack.py
@@ -273,10 +273,8 @@ file_type = {TRACK_TYPE}
         bed_file_h, total_length = self.get_bed_handler(plot_regions)
         self.bed_type = bed_file_h.file_type
 
-        if self.properties['color'] == 'bed_rgb' and \
-           self.bed_type not in ['bed12', 'bed9']:
-            self.log.warning("*WARNING* Color set to 'bed_rgb', "
-                             "but bed file does not have the rgb field. "
+        if self.properties['color'] == 'bed_rgb' and self.bed_type not in ['bed12', 'bed9']:
+            self.log.warning("*WARNING* Color set to 'bed_rgb', but bed file does not have the rgb field. "
                              f"The color has been set to {DEFAULT_BED_COLOR}.\n")
             self.properties['color'] = DEFAULT_BED_COLOR
 

--- a/pygenometracks/tracks/BedTrack.py
+++ b/pygenometracks/tracks/BedTrack.py
@@ -294,10 +294,8 @@ file_type = {TRACK_TYPE}
         bed_file_h, total_length = self.get_bed_handler(plot_regions)
         self.bed_type = bed_file_h.file_type
 
-        if self.properties['color'] == 'bed_rgb' and \
-           self.bed_type not in ['bed12', 'bed9']:
-            self.log.warning("*WARNING* Color set to 'bed_rgb', "
-                             "but bed file does not have the rgb field. "
+        if self.properties['color'] == 'bed_rgb' and self.bed_type not in ['bed12', 'bed9']:
+            self.log.warning("*WARNING* Color set to 'bed_rgb', but bed file does not have the rgb field. "
                              f"The color has been set to {DEFAULT_BED_COLOR}.\n")
             self.properties['color'] = DEFAULT_BED_COLOR
 

--- a/pygenometracks/tracks/BedTrack.py
+++ b/pygenometracks/tracks/BedTrack.py
@@ -628,6 +628,13 @@ file_type = {TRACK_TYPE}
             ax.set_ylim(ylims[1], ylims[0])
 
     def plot_label(self, label_ax, width_dpi, h_align='left'):
+        """
+        Plot the label of the track.
+
+        :param label_ax: the axis where to plot the label
+        :param width_dpi: the width of the figure in dpi
+        :param h_align: the horizontal alignment of the label. Options are 'left', 'right' or 'center'
+        """
         if h_align == 'left':
             label_ax.text(0.05, 1, self.properties['title'],
                           horizontalalignment='left', size='large',
@@ -651,7 +658,16 @@ file_type = {TRACK_TYPE}
             # To be able to wrap to the left:
             txt._get_wrap_line_width = lambda: width_dpi
 
-    def plot_y_axis(self, ax, plot_axis):
+    def plot_y_axis(self, ax, plot_axis, transform='no', log_pseudocount=0, y_axis='tranformed', only_at_ticks=False):
+        """
+        Plot the y-axis of the track. Overwrite the GenomeTrack method to have bed specific y-axis plotting.
+        When a color map is used for the color in the .ini file (e.g. coolwarm, Reds), the bed score column mapped to a
+        color.
+
+        :param ax: the axis where to plot the y axis
+        :param plot_axis: whether to plot the axis or not
+        :return: None
+        """
         if self.colormap is not None:
             self.colormap.set_array([])
             GenomeTrack.plot_custom_cobar(self, ax, fraction=1)

--- a/pygenometracks/tracks/BedTrack.py
+++ b/pygenometracks/tracks/BedTrack.py
@@ -663,6 +663,13 @@ file_type = {TRACK_TYPE}
         self.log.debug(f"ylim {ax.get_ylim()}")
 
     def plot_label(self, label_ax, width_dpi, h_align='left'):
+        """
+        Plot the label of the track.
+
+        :param label_ax: the axis where to plot the label
+        :param width_dpi: the width of the figure in dpi
+        :param h_align: the horizontal alignment of the label. Options are 'left', 'right' or 'center'
+        """
         if h_align == 'left':
             label_ax.text(0.05, 1, self.properties['title'],
                           horizontalalignment='left', size='large',
@@ -686,7 +693,16 @@ file_type = {TRACK_TYPE}
             # To be able to wrap to the left:
             txt._get_wrap_line_width = lambda: width_dpi
 
-    def plot_y_axis(self, ax, plot_axis):
+    def plot_y_axis(self, ax, plot_axis, transform='no', log_pseudocount=0, y_axis='tranformed', only_at_ticks=False):
+        """
+        Plot the y-axis of the track. Overwrite the GenomeTrack method to have bed specific y-axis plotting.
+        When a color map is used for the color in the .ini file (e.g. coolwarm, Reds), the bed score column mapped to a
+        color.
+
+        :param ax: the axis where to plot the y axis
+        :param plot_axis: whether to plot the axis or not
+        :return: None
+        """
         if self.colormap is not None:
             self.colormap.set_array([])
             GenomeTrack.plot_custom_cobar(self, ax, fraction=1)

--- a/pygenometracks/tracks/GenomeTrack.py
+++ b/pygenometracks/tracks/GenomeTrack.py
@@ -81,21 +81,17 @@ height = 2
                                  f"{default_value}.\n")
                 self.properties[prop] = default_value
 
-    def plot_y_axis(self, ax, plot_axis, transform='no', log_pseudocount=0,
-                    y_axis='transformed', only_at_ticks=False):
+    def plot_y_axis(self, ax, plot_axis, transform='no', log_pseudocount=0, y_axis='tranformed', only_at_ticks=False):
         """
-        Plot the scale of the y axis with respect to the plot_axis
-        Args:
-            ax: axis to use to plot the scale
-            plot_axis: the reference axis to get the max and min.
-            transform: what was the transformation of the data
-            log_pseudocount:
-            y_axis: 'transformed' or 'original'
-            only_at_ticks: False: only min_max are diplayed
-                           True: only ticks values are displayed
+        Plot the scale of the y-axis with respect to the plot_axis.
 
-        Returns:
-
+        :param ax: axis to use to plot the scale
+        :param plot_axis: the reference axis to get the max and min.
+        :param transform: what was the transformation of the data
+        :param log_pseudocount:
+        :param y_axis: 'tranformed' or 'original'
+        :param only_at_ticks: False: only min_max are diplayed. True: only ticks values are displayed
+        :return:
         """
         if not self.properties.get('show_data_range', True):
             return
@@ -142,11 +138,8 @@ height = 2
                 prefix = ""
             exponent = math.floor(np.log10(value))
             value_scien = value / 10 ** exponent
-            # Find the number of decimal values
-            # that would be possible to fit in
-            # max_signs
-            # At max it is max_signs - 1 because you need
-            # one sign before the '.'
+            # Find the number of decimal values that would be possible to fit in  max_signs
+            # At max it is max_signs - 1 because you need one sign before the '.'
             sigfigs = max_signs - 1
             while sigfigs >= 0:
                 if np.abs(value_scien - np.round(value_scien, decimals=sigfigs)) < 1 * 10 ** (-max_signs + 1):
@@ -198,8 +191,15 @@ height = 2
             return prefix + ("{:,." + str(sigfigs) + "f}").format(value) + suffix
 
         def untransform(value, transform, log_pseudocount):
-            # given a numeric value, transform and log_pseudocount
-            # return the value before the transformation
+            """
+            Given a numeric value, transform and log_pseudocount.
+            Return the value before the transformation.
+
+            :param value:
+            :param transform: Type of transformation. Options are 'log', 'log2', 'log10', 'log1p', '-log'
+            :param log_pseudocount:
+            :return: Untransformed value
+            """
             if transform == 'log':
                 return np.exp(value) - log_pseudocount
             elif transform == 'log2':

--- a/pygenometracks/tracks/GenomeTrack.py
+++ b/pygenometracks/tracks/GenomeTrack.py
@@ -81,21 +81,17 @@ height = 2
                                  f"{default_value}.\n")
                 self.properties[prop] = default_value
 
-    def plot_y_axis(self, ax, plot_axis, transform='no', log_pseudocount=0,
-                    y_axis='tranformed', only_at_ticks=False):
+    def plot_y_axis(self, ax, plot_axis, transform='no', log_pseudocount=0, y_axis='tranformed', only_at_ticks=False):
         """
-        Plot the scale of the y axis with respect to the plot_axis
-        Args:
-            ax: axis to use to plot the scale
-            plot_axis: the reference axis to get the max and min.
-            transform: what was the transformation of the data
-            log_pseudocount:
-            y_axis: 'tranformed' or 'original'
-            only_at_ticks: False: only min_max are diplayed
-                           True: only ticks values are displayed
+        Plot the scale of the y-axis with respect to the plot_axis.
 
-        Returns:
-
+        :param ax: axis to use to plot the scale
+        :param plot_axis: the reference axis to get the max and min.
+        :param transform: what was the transformation of the data
+        :param log_pseudocount:
+        :param y_axis: 'tranformed' or 'original'
+        :param only_at_ticks: False: only min_max are diplayed. True: only ticks values are displayed
+        :return:
         """
         if not self.properties.get('show_data_range', True):
             return
@@ -142,11 +138,8 @@ height = 2
                 prefix = ""
             exponent = math.floor(np.log10(value))
             value_scien = value / 10 ** exponent
-            # Find the number of decimal values
-            # that would be possible to fit in
-            # max_signs
-            # At max it is max_signs - 1 because you need
-            # one sign before the '.'
+            # Find the number of decimal values that would be possible to fit in  max_signs
+            # At max it is max_signs - 1 because you need one sign before the '.'
             sigfigs = max_signs - 1
             while sigfigs >= 0:
                 if np.abs(value_scien - np.round(value_scien, decimals=sigfigs)) < 1 * 10 ** (-max_signs + 1):
@@ -198,8 +191,15 @@ height = 2
             return prefix + ("{:,." + str(sigfigs) + "f}").format(value) + suffix
 
         def untransform(value, transform, log_pseudocount):
-            # given a numeric value, transform and log_pseudocount
-            # return the value before the transformation
+            """
+            Ggiven a numeric value, transform and log_pseudocount.
+            Return the value before the transformation.
+
+            :param value:
+            :param transform: Type of transformation. Options are 'log', 'log2', 'log10', 'log1p', '-log'
+            :param log_pseudocount:
+            :return: Untransformed value
+            """
             if transform == 'log':
                 return np.exp(value) - log_pseudocount
             elif transform == 'log2':

--- a/pygenometracks/tracks/GtfTrack.py
+++ b/pygenometracks/tracks/GtfTrack.py
@@ -174,8 +174,7 @@ file_type = {TRACK_TYPE}
     def get_bed_handler(self, plot_regions=None):
         if not self.properties['global_max_row']:
             # I do the intersection:
-            file_to_open = temp_file_from_intersect(self.properties['file'],
-                                                    plot_regions, AROUND_REGION)
+            file_to_open = temp_file_from_intersect(self.properties['file'], plot_regions, AROUND_REGION)
         else:
             file_to_open = self.properties['file']
 

--- a/pygenometracks/tracks/GtfTrack.py
+++ b/pygenometracks/tracks/GtfTrack.py
@@ -193,8 +193,7 @@ file_type = {TRACK_TYPE}
     def get_bed_handler(self, plot_regions=None):
         if not self.properties['global_max_row']:
             # I do the intersection:
-            file_to_open = temp_file_from_intersect(self.properties['file'],
-                                                    plot_regions, AROUND_REGION)
+            file_to_open = temp_file_from_intersect(self.properties['file'], plot_regions, AROUND_REGION)
         else:
             file_to_open = self.properties['file']
 

--- a/pygenometracks/tracks/GwasTrack.py
+++ b/pygenometracks/tracks/GwasTrack.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from .GenomeTrack import GenomeTrack
 import numpy as np
-import pandas as pd  # TODO: package is not otherwise pandas dependent. Should probably remove.
+import pandas as pd  # TODO: package is not otherwise pandas dependent (uses custom scripts to read data in). Should probably do the same.
 
 
 # Expects .gwas file

--- a/pygenometracks/tracks/GwasTrack.py
+++ b/pygenometracks/tracks/GwasTrack.py
@@ -24,10 +24,11 @@ file =
 ylabel =
 # Fontsize of the labels
 fontsize =
+# Color of accentuated points (CS = 1)
+color =
 """
     DEFAULTS_PROPERTIES = {'fontsize': 6,
-                           'orientation': None,
-                           'color': 'grey',
+                           'color': 'red',
                            'border_color': 'black',
                            'labels': True,
                            'line_width': 0.5,
@@ -35,18 +36,53 @@ fontsize =
                            'max_value': 1,
                            'min_value': 0,
                            'fontstyle': 'normal',
-                           'ylabel': None}
+                           'ylabel': None,
+                           'y_values_format': 'pval',
+                           'y_axis_max_val': None,
+                           'id_fontsize': 12,
+                           'cs_dotsize': 45}
 
     NECESSARY_PROPERTIES = ['file']
     SYNONYMOUS_PROPERTIES = {}
-    POSSIBLE_PROPERTIES = {}
+    POSSIBLE_PROPERTIES = {'y_values_format': ['PP', '-log10', 'pval']}
     BOOLEAN_PROPERTIES = []
-    STRING_PROPERTIES = ['title', 'file_type', 'file', 'ylabel']
-    FLOAT_PROPERTIES = {'height': [0, np.inf], 'fontsize': [0, np.inf]}
+    STRING_PROPERTIES = ['title', 'file_type', 'file', 'ylabel', 'y_values_format', 'color']
+    FLOAT_PROPERTIES = {'height': [0, np.inf], 'fontsize': [0, np.inf], 'id_fontsize': [0, np.inf], 'cs_dotsize': [0, np.inf], 'y_axis_max_val': [0, np.inf]}
     INTEGER_PROPERTIES = {}
 
     def __init__(self, *args, **kwarg):
         super(GwasTrack, self).__init__(*args, **kwarg)
+
+    def process_gwas(self):
+        """
+        Process input .gwas file to a pandas dataframe.
+        Read the file, check it has all the required columns. Add CS and INT columns if not present.
+        If y_values_format is -log10, transform the P-values to -log10(P).
+
+        :return: pandas dataframe with the data, and the maximum value of the y-axis
+        """
+        f = self.properties['file']
+        df = pd.read_csv(f, sep='\t')
+        # Check the columns of the df include the required columns (CHR, BP, SNP, P)
+        required_columns = ['CHR', 'BP', 'SNP', 'P']
+        for column in required_columns:
+            if column not in df.columns:
+                raise ValueError(f"File {f} does not contain required column {column}")
+
+        # Add columns for CS and INT if they don't exist (standard IGV .gwas format)
+        if 'CS' not in df.columns:
+            df['CS'] = '0'  # TODO: these should be set to 0 when we make the change to 0/1 instead of NO/YES. /done now
+        if 'INT' not in df.columns:
+            df['INT'] = '0'
+
+        # For the -log10 scale, calculate the -log10 of the P-value
+        if self.properties['y_values_format'] == '-log10':
+            df['P'] = df['P'].apply(lambda v: -np.log10(v))
+
+        # Maximum value of the y-axis, rounded up
+        maxval = np.ceil(df['P'].max())
+
+        return df, maxval
 
     def plot(self, ax, chrom, region_start, region_end):
         """
@@ -59,13 +95,9 @@ fontsize =
         :param end_region: end coordinate
         """
 
-        f = self.properties['file']
-        df = pd.read_csv(f, sep='\t')
-        # Check the columns of the df include the required columns (CHR, BP, SNP, P)
-        required_columns = ['CHR', 'BP', 'SNP', 'P']
-        for c in required_columns:
-            if c not in df.columns:
-                raise ValueError(f"File {f} does not contain required column {c}")
+        df, max_y = self.process_gwas()
+        if self.properties['y_axis_max_val']:
+            max_y = self.properties['y_axis_max_val']
 
         x = df['BP']
 
@@ -76,43 +108,56 @@ fontsize =
             """
             if val > 0.95:
                 return 0.95
-            elif val < 0.02:
-                return 0.02
+            elif val < max_y/20:
+                return max_y/20
             else:
                 return val
 
-        y = df['P'].apply(floor)
+        if self.properties['y_values_format'] == 'PP':
+            y = df['P'].apply(floor)
+            if max_y > 1:
+                print("Y axis cannot be bigger than 1 for Posterior Probabilities!")
+                max_y = 1
+            ax.set_ylim(bottom=0, top=max_y)
+        elif self.properties['y_values_format'] == '-log10':
+            y = df['P']  # Values are already -log10 transformed by process_gwas()
+            ax.set_ylim(bottom=0, top=max_y)
+        elif self.properties['y_values_format'] == 'pval':
+            print(self.properties['y_values_format'])
+            y = df['P']
+        else:
+            raise ValueError(f"y_values_format {self.properties['y_values_format']} not recognized.")
 
-        ax.scatter(x, y, s=10, color='grey')
+        ax.scatter(x, y, s=10, color='grey')  # The color of the non-CS points is grey
 
-        ax.set_ylim(bottom=0, top=1)
-
-        # PLOT LEAD VARIANTS, CS COL MARKED AS 1
+        # Plot the Credible Set variants on top of the grey points
         if 'CS' in df.columns:
-            sub = df[df.CS == 'YES']
+            sub = df[df.CS == 1]
 
             x = sub['BP'].tolist()
-            y = sub['P'].apply(floor).tolist()
+            if self.properties['y_values_format'] == 'PP':
+                y = sub['P'].apply(floor).tolist()
+            else:
+                y = sub['P'].tolist()
 
         if 'INT' in df.columns:  # TODO: this is temporary. Needs to be far more robust.
             # Names will be a list with '' in the positions where INT is not YES and the value of the SNP column otherwise.
-            names = sub.apply(lambda row: row['SNP'] if row['INT'] == 'YES' else '', axis=1).tolist()
+            names = sub.apply(lambda row: row['SNP'] if row['INT'] == 1 else '', axis=1).tolist()
 
-        ax.scatter(x, y, s=40, color='red', marker='h')
-
+        ax.scatter(x, y, s=self.properties['cs_dotsize'], color=self.properties['color'], marker='o',
+                   edgecolors='black', linewidths=.66)
+        print("NAMES: ", names)
         for i, n in enumerate(names):
             xy = (x[i], y[i])
-            ax.text(xy[0], xy[1], n, fontsize=12, ha='center', va='bottom')
+            ax.text(xy[0], xy[1] + 0.01, n, fontsize=self.properties['id_fontsize'], ha='center', va='bottom', snap=True)
 
-    def plot_y_axis(self, ax, plot_axis, transform='no', log_pseudocount=0, y_axis='transformed', only_at_ticks=False):
+    def plot_y_axis(self, ax, plot_axis, transform='no', log_pseudocount=0, y_axis='transformed', only_at_ticks=False,
+                    add_ylabel=True, ylabel_text=None):
         """
-        Plot the y-axis of the track. This overwrites the GenomeTrack.plot_y_axis method.
+        Override the GenomeTrack.plot_y_axis method to add a y-axis label to the normally label-less y-axis.
         """
-        # Add y axis label
-        # TODO: this does not work. The idea is to add a label to the y axis so that we can specify the unit.
-        # Currently, I am trying to plot the title of the track, but it does not work:(
         GenomeTrack.plot_y_axis(self, ax, plot_axis, transform, log_pseudocount, y_axis, only_at_ticks, add_ylabel=True,
                                 ylabel_text=self.properties['ylabel'])
 
-    #def plot_label(self, label_ax, width_dpi, h_align='left'):
+    # def plot_label(self, label_ax, width_dpi, h_align='left'):
     #    pass

--- a/pygenometracks/tracks/GwasTrack.py
+++ b/pygenometracks/tracks/GwasTrack.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+from .GenomeTrack import GenomeTrack
+import numpy as np
+import pandas as pd  # TODO: package is not otherwise pandas dependent. Should probably remove.
+
+
+# Expects .gwas file
+
+
+class GwasTrack(GenomeTrack):
+    SUPPORTED_ENDINGS = ['gwas']  # this is used by make_tracks_file to guess the type of track based on file name
+    TRACK_TYPE = 'gwas'
+    OPTIONS_TXT = """
+height = 3
+title =
+text =
+# x position of text in the plot (in bp)
+x position =
+"""
+    DEFAULTS_PROPERTIES = {'fontsize': 6,
+                           'orientation': None,
+                           'color': 'grey',
+                           'border_color': 'black',
+                           'labels': True,
+
+                           'line_width': 0.5,
+                           'max_labels': 60,
+                           'max_value': 1,
+                           'min_value': 0,
+                           'fontstyle': 'normal'}
+
+    NECESSARY_PROPERTIES = ['file']
+    SYNONYMOUS_PROPERTIES = {}
+    POSSIBLE_PROPERTIES = {}
+    BOOLEAN_PROPERTIES = []
+    STRING_PROPERTIES = ['title', 'file_type', 'file']
+    FLOAT_PROPERTIES = {'height': [0, np.inf],
+                        'x_position': [0, np.inf]}
+    INTEGER_PROPERTIES = {}
+
+    def __init__(self, *args, **kwarg):
+        super(GwasTrack, self).__init__(*args, **kwarg)
+
+    def plot(self, ax, chrom, region_start, region_end):
+        """
+        Plot the given title at a fixed location in the axis.
+        The chrom, region_start and region_end variables are not used at the moment.
+
+        :param ax: matplotlib axis to plot
+        :param chrom_region: chromosome name
+        :param start_region: start coordinate of genomic position
+        :param end_region: end coordinate
+        """
+
+        f = self.properties['file']
+        df = pd.read_csv(f, sep='\t')
+        x = df['BP']
+
+        def floor(val):
+            """
+            Alter values to be between 0.02 and 0.95 to avoid cropping by matplotlib.
+            TODO: This is a hacky and temporary solution, and does not apply when P is a P-value and not a PP.
+            """
+            if val > 0.95:
+                return 0.95
+            elif val < 0.02:
+                return 0.02
+            else:
+                return val
+
+        y = df['P'].apply(floor)
+        # print text at position x = self.properties['x position'] and y = 0.5 (center of the plot)
+
+        labels = [item.get_text() for item in ax.get_yticklabels()]
+        ax.scatter(x, y, s=10, color='grey')
+
+        ax.set_ylim(bottom=0, top=1)
+
+        # PLOT LEAD VARIANTS, CS COL MARKED AS 1
+
+        sub = df[df.CS == 'YES']
+
+        x = sub['BP'].tolist()
+        y = sub['P'].apply(floor).tolist()
+        names = sub['INT'].tolist()
+
+        ax.scatter(x, y, s=40, color='red', marker='h')
+
+        for i, n in enumerate(names):
+            xy = (x[i], y[i])
+
+    def plot_y_axis(self, ax, plot_axis, transform='no', log_pseudocount=0, y_axis='tranformed', only_at_ticks=False):
+        """
+        Plot the y-axis of the track. This overwrites the GenomeTrack.plot_y_axis method.
+        """
+        # Add y axis label
+        # TODO: this does not work. The idea is to add a label to the y axis so that we can specify the unit.
+        # Currently, I am trying to plot the title of the track, but it does not work:(
+        if self.properties['title']:
+            ax.set_ylabel(self.properties['title'], fontsize=self.properties['fontsize'])
+
+        GenomeTrack.plot_y_axis(self, ax, plot_axis, transform, log_pseudocount, y_axis, only_at_ticks)
+
+    def plot_label(self, label_ax, width_dpi, h_align='left'):
+        pass

--- a/pygenometracks/tracks/GwasTrack.py
+++ b/pygenometracks/tracks/GwasTrack.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+from .GenomeTrack import GenomeTrack
+import numpy as np
+import pandas as pd
+
+
+# Expects .gwas file
+
+
+class GwasTrack(GenomeTrack):
+    SUPPORTED_ENDINGS = ['gwas']  # this is used by make_tracks_file to guess the type of track based on file name
+    TRACK_TYPE = 'gwas'
+    OPTIONS_TXT = """
+height = 3
+title =
+text =
+# x position of text in the plot (in bp)
+x position =
+"""
+    DEFAULTS_PROPERTIES = {'fontsize': 6,
+                           'orientation': None,
+                           'color': 'grey',
+                           'border_color': 'black',
+                           'labels': True,
+
+                           'line_width': 0.5,
+                           'max_labels': 60,
+                           'max_value': 1,
+                           'min_value': 0,
+                           'fontstyle': 'normal'}
+
+    NECESSARY_PROPERTIES = ['file']
+    SYNONYMOUS_PROPERTIES = {}
+    POSSIBLE_PROPERTIES = {}
+    BOOLEAN_PROPERTIES = []
+    STRING_PROPERTIES = ['title', 'file_type', 'file']
+    FLOAT_PROPERTIES = {'height': [0, np.inf],
+                        'x_position': [0, np.inf]}
+    INTEGER_PROPERTIES = {}
+
+    def __init__(self, *args, **kwarg):
+        super(GwasTrack, self).__init__(*args, **kwarg)
+
+    def plot(self, ax, chrom, region_start, region_end):
+        """
+        Plot the given title at a fixed location in the axis.
+        The chrom, region_start and region_end variables are not used at the moment.
+
+        :param ax: matplotlib axis to plot
+        :param chrom_region: chromosome name
+        :param start_region: start coordinate of genomic position
+        :param end_region: end coordinate
+        """
+
+        f = self.properties['file']
+        df = pd.read_csv(f, sep='\t')
+        x = df['BP']
+
+        def floor(val):
+            """
+            Alter values to be between 0.02 and 0.95 to avoid cropping by matplotlib.
+            TODO: This is a hacky and temporary solution, and does not apply when P is a P-value and not a PP.
+            """
+            if val > 0.95:
+                return 0.95
+            elif val < 0.02:
+                return 0.02
+            else:
+                return val
+
+        y = df['P'].apply(floor)
+        # print text at position x = self.properties['x position'] and y = 0.5 (center of the plot)
+
+        labels = [item.get_text() for item in ax.get_yticklabels()]
+        ax.scatter(x, y, s=10, color='grey')
+
+        ax.set_ylim(bottom=0, top=1)
+
+        # PLOT LEAD VARIANTS, CS COL MARKED AS 1
+
+        sub = df[df.CS == 'YES']
+
+        x = sub['BP'].tolist()
+        y = sub['P'].apply(floor).tolist()
+        names = sub['INT'].tolist()
+
+        ax.scatter(x, y, s=40, color='red', marker='h')
+
+        for i, n in enumerate(names):
+            xy = (x[i], y[i])
+
+    def plot_y_axis(self, ax, plot_axis, transform='no', log_pseudocount=0, y_axis='tranformed', only_at_ticks=False):
+        """
+        Plot the y-axis of the track. This overwrites the GenomeTrack.plot_y_axis method.
+        """
+        # Add y axis label
+        # TODO: this does not work. The idea is to add a label to the y axis so that we can specify the unit.
+        # Currently, I am trying to plot the title of the track, but it does not work:(
+        if self.properties['title']:
+            ax.set_ylabel(self.properties['title'], fontsize=self.properties['fontsize'])
+
+        GenomeTrack.plot_y_axis(self, ax, plot_axis, transform, log_pseudocount, y_axis, only_at_ticks)
+
+    def plot_label(self, label_ax, width_dpi, h_align='left'):
+        pass

--- a/pygenometracks/tracksClass.py
+++ b/pygenometracks/tracksClass.py
@@ -644,14 +644,14 @@ class PlotTracks(object):
             unused_keys = []
             # Now we can proceed with the keywords:
             for name, value in parser.items(section_name):
-                # To be removed in the next 1.0 version
-                if ' ' in name:
+                if ' ' in name:  # Deal with spaces in the name
                     old_name = name
                     name = '_'.join(name.split(' '))
                     log.warning(f"Deprecated Warning: The section {section_name} uses parameter {old_name} but there "
                                 f"is no more parameter with space in name. Will be substituted by {name}.\n")
                 else:
                     old_name = name
+
                 SYNONYMOUS_PROPERTIES = track_class.SYNONYMOUS_PROPERTIES
                 # If the name is part of the synonymous we substitute by the synonymous value
                 if name in SYNONYMOUS_PROPERTIES and value in SYNONYMOUS_PROPERTIES[name]:

--- a/pygenometracks/tracksClass.py
+++ b/pygenometracks/tracksClass.py
@@ -28,14 +28,9 @@ warnings.simplefilter(action='ignore', category=FutureWarning)
 warnings.simplefilter(action='ignore', category=DeprecationWarning)
 warnings.simplefilter(action='ignore', category=ImportWarning)
 
-# import warnings
-# warnings.filterwarnings('error')
-
 FORMAT = "[%(levelname)s:%(filename)s:%(lineno)s - %(funcName)20s()] %(message)s"
 logging.basicConfig(format=FORMAT)
 log = logging.getLogger(__name__)
-# logging.basicConfig()
-# log = logging.getLogger("tracksClass")
 log.setLevel(logging.DEBUG)
 
 DEFAULT_TRACK_HEIGHT = 0.5  # in centimeters
@@ -44,11 +39,11 @@ DEFAULT_MARGINS = {'left': 0.04, 'right': 0.92, 'bottom': 0.03, 'top': 0.97}
 
 
 class VType(object):
-    """The VType object is a holder for all vertical types
-    which will be plotted above other tracks.
-
-    It is expected that all VType has a plot method
     """
+    The VType object is a holder for all vertical types which will be plotted above other tracks.
+    It is expected that VType objects always has a plot method.
+    """
+
     DEFAULTS_PROPERTIES = {}
     NECESSARY_PROPERTIES = []
     SYNONYMOUS_PROPERTIES = {}
@@ -108,6 +103,10 @@ class VType(object):
 
 
 class VlineType(VType):
+    """
+    Extends the VType class to plot vertical lines across all tracks.
+    """
+
     TYPE = 'vlines'
     OPTIONS_TXT = f"""
 # Mandatory:
@@ -158,15 +157,15 @@ type = {TYPE}
     def plot(self, axis_list, figure, chrom_region, start_region, end_region):
         """
         If the zorder is positive:
-        Plots lines from the top of the first plot to the bottom
-        of the last plot at the specified positions.
+        Plots lines from the top of the first plot to the bottom of the last plot at the specified positions.
         Else:
         Plots vlines on each track
 
         :param axis_list: list of plotted axis
-        :param chrom_region chromosome name
-        :param start_region start position
-        :param end_region end position
+        :param figure: matplotlib figure
+        :param chrom_region: chromosome name
+        :param start_region: start position
+        :param end_region: end position
 
         :return: None
         """
@@ -196,6 +195,10 @@ type = {TYPE}
 
 
 class VhighlightType(VType):
+    """
+    Highlight a whole region across all tracks.
+    """
+
     TYPE = 'vhighlight'
     OPTIONS_TXT = f"""
 # Mandatory:
@@ -279,10 +282,7 @@ type = {TYPE}
 
 class MultiDict(OrderedDict):
     """
-    Class to allow identically named
-    sections in configuration file
-    by appending the section number as
-    for example:
+    Class to allow identically named sections in configuration file by appending the section number as for example:
     1. section name
     """
     _unique = 0
@@ -295,11 +295,33 @@ class MultiDict(OrderedDict):
 
 
 class PlotTracks(object):
+    """
+    Object to plot tracks. Methods are:
+    - get_available_tracks: returns a dictionary of all available tracks
+    - get_available_types: returns a dictionary of all available types
+    - get_tracks_height: returns a list of the height of each track
+    - plot: plots the tracks in the given region
+    - parse_tracks: parses a configuration file
+    - close_files: closes all files
+    - check_fil_exists: checks if a file or list of files exist
+    - guess_filetype: guesses the file type based on the file name
+    - cm2inch: converts centimeters to inches
+    - print_elapsed: prints the elapsed time for the log
 
-    def __init__(self, tracks_file, fig_width=DEFAULT_FIGURE_WIDTH,
-                 fig_height=None, fontsize=None, dpi=None,
-                 track_label_width=0.1,
-                 plot_regions=None, plot_width=None):
+
+    """
+    def __init__(self, tracks_file, fig_width=DEFAULT_FIGURE_WIDTH, fig_height=None, fontsize=None, dpi=None,
+                 track_label_width=0.1, plot_regions=None, plot_width=None):
+        """
+        :param tracks_file: path to the .ini configuration file
+        :param fig_width: width of the figure in centimeters
+        :param fig_height: height of the figure in centimeters
+        :param fontsize: fontsize of the track titles
+        :param dpi: dpi of the figure
+        :param track_label_width: width of the track title in the figure
+        :param plot_regions: a list of tuples [(chrom1, start1, end1), (chrom2, start2, end2)]
+        :param plot_width: width of the plot in centimeters
+        """
         self.fig_width = fig_width
         self.fig_height = fig_height
         self.dpi = dpi
@@ -350,6 +372,9 @@ class PlotTracks(object):
 
     @staticmethod
     def get_available_tracks():
+        """
+        Returns a dictionary of all available tracks
+        """
         avail_tracks = {}
         work = [GenomeTrack]
         while work:
@@ -376,19 +401,13 @@ class PlotTracks(object):
 
     def get_tracks_height(self, start_region=None, end_region=None):
         """
-        The main purpose of the following loop is
-        to get the height of each of the tracks
-        because for the Hi-C the height is variable with respect
-        to the range being plotted, the function is called
-        when each plot is going to be printed.
+        The main purpose of the following loop is to get the height of each of the tracks because for the Hi-C the
+        height is variable with respect to the range being plotted, the function is called when each plot is going to
+        be printed.
 
-        Args:
-            start_region: start of the region to plot.
-                          Only used in case the plot is a Hi-C matrix
-            end_region: end of the region to plot.
-                        Only used in case the plot is a Hi-C matrix
-
-        Returns:
+        :param start_region: start of the region to plot. Only used in case the plot is a Hi-C matrix
+        :param end_region: end of the region to plot. Only used in case the plot is a Hi-C matrix
+        :return: a list of the height of each track
 
         """
         track_height = []
@@ -464,19 +483,27 @@ class PlotTracks(object):
 
         return track_height
 
-    def plot(self, file_name, chrom, start, end, title=None,
-             h_align_titles='left', decreasing_x_axis=False):
-        track_height = self.get_tracks_height(start_region=start,
-                                              end_region=end)
+    def plot(self, file_name, chrom, start, end, title=None, h_align_titles='left', decreasing_x_axis=False):
+        """
+        Plot the tracks in the given region. The region is specified by the chrom, start and end parameters.
+
+        :param file_name: name of the file to save the plot
+        :param chrom: chromosome name
+        :param start: start position
+        :param end: end position
+        :param title: title of the plot
+        :param h_align_titles: horizontal alignment of the track titles. Can be 'left', 'center' or 'right'
+        :param decreasing_x_axis: if True, the x-axis is inverted
+        :return: None
+        """
+        track_height = self.get_tracks_height(start_region=start, end_region=end)
 
         if self.fig_height:
             fig_height = self.fig_height
         else:
-            fig_height = sum(track_height) / \
-                (DEFAULT_MARGINS['top'] - DEFAULT_MARGINS['bottom'])
+            fig_height = sum(track_height) / (DEFAULT_MARGINS['top'] - DEFAULT_MARGINS['bottom'])
 
-        log.debug(f"Figure size in cm is {self.fig_width} x {fig_height}."
-                  f" Dpi is set to {self.dpi}\n")
+        log.debug(f"Figure size in cm is {self.fig_width} x {fig_height}. Dpi is set to {self.dpi}\n")
         fig = plt.figure(figsize=self.cm2inch(self.fig_width, fig_height))
 
         fig.subplots_adjust(wspace=0, hspace=0.0,
@@ -493,8 +520,7 @@ class PlotTracks(object):
                                              width_ratios=self.width_ratios,
                                              wspace=0.01)
         axis_list = []
-        # skipped_tracks is the count of tracks that have the
-        # 'overlay_previous' parameter and should be skipped
+        # skipped_tracks is the count of tracks that have the 'overlay_previous' parameter and should be skipped
         skipped_tracks = 0
         plot_axis = None
         for idx, track in enumerate(self.track_obj_list):
@@ -531,10 +557,11 @@ class PlotTracks(object):
                 plot_axis.set_xlim(end, start)
             else:
                 plot_axis.set_xlim(start, end)
+
+            # Plot the track and the additional axis
             track.plot(plot_axis, chrom, start, end)
             track.plot_y_axis(y_axis, plot_axis)
-            track.plot_label(label_axis, width_dpi=width_dpi,
-                             h_align=h_align_titles)
+            track.plot_label(label_axis, width_dpi=width_dpi, h_align=h_align_titles)
 
             if track.properties['overlay_previous'] == 'share-y':
                 plot_axis.set_ylim(ylim)
@@ -552,8 +579,8 @@ class PlotTracks(object):
         """
         Parses a configuration file
 
-        :param tracks_file: file path containing the track configuration
-        :param plot_regions: a list of tuple [(chrom1, start1, end1), (chrom2, start2, end2)]
+        :param tracks_file: file path containing the track configuration (.ini file)
+        :param plot_regions: a list of tuples [(chrom1, start1, end1), (chrom2, start2, end2)]
                              on which the data should be loaded
                              here the vlines and the vhightlight
         :return: None
@@ -570,17 +597,14 @@ class PlotTracks(object):
             track_options = dict({"section_name": section_name})
             all_keywords = [i[0] for i in parser.items(section_name)]
             # First we check if there is a skip set to true:
-            if 'skip' in all_keywords and \
-               parser.getboolean(section_name, 'skip'):
+            if 'skip' in all_keywords and parser.getboolean(section_name, 'skip'):
                 # In this case we just do not explore the section
                 continue
-            # We will append properties dictionnaries
-            # to the track_list or type_list
+            # We will append properties dictionaries to the track_list or type_list
             # Then the types are treated slightly differently:
             if 'type' in all_keywords and parser.get(section_name, 'type') in self.available_types:
                 track_options['type'] = parser.get(section_name, 'type')
-                track_options['track_class'] = \
-                    self.available_types[track_options['type']]
+                track_options['track_class'] = self.available_types[track_options['type']]
             # If the sections are spacer or x-axis we fill the file_type:
             # (They are special sections where the title defines the track type)
             elif section_name.endswith('[spacer]'):
@@ -592,40 +616,26 @@ class PlotTracks(object):
             # For the others we need to have a 'file_type'
             # Either the file_type is part of the keywords
             elif 'file_type' in all_keywords:
-                track_options['file_type'] = parser.get(section_name,
-                                                        'file_type')
+                track_options['file_type'] = parser.get(section_name, 'file_type')
                 if track_options['file_type'] not in self.available_tracks:
-                    raise InputError(f"Section {section_name}: the file_type "
-                                     f"{track_options['file_type']} does not"
-                                     " exists.\npossible file_type are:"
-                                     f"{self.available_tracks.keys()}.")
-                track_options['track_class'] = \
-                    self.available_tracks[track_options['file_type']]
+                    raise InputError(f"Section {section_name}: the file_type {track_options['file_type']} does not "
+                                     f"exist.\npossible file_type are: {self.available_tracks.keys()}.")
+                track_options['track_class'] = self.available_tracks[track_options['file_type']]
             # Or we guess it from the file:
             elif 'file' in all_keywords:
-                track_options['file'] = parser.get(section_name,
-                                                   'file')
-                track_options['file_type'] = \
-                    self.guess_filetype(track_options,
-                                        self.available_tracks)
-                track_options['track_class'] = \
-                    self.available_tracks[track_options['file_type']]
+                track_options['file'] = parser.get(section_name, 'file')
+                track_options['file_type'] = self.guess_filetype(track_options, self.available_tracks)
+                track_options['track_class'] = self.available_tracks[track_options['file_type']]
             else:
-                raise InputError(f"Section {section_name}: there is no file_type nor file "
-                                 "specified and it is not a [spacer] nor a "
-                                 "[x-axis] section. This is not a valid "
-                                 "section.")
-            # Now we should have a 'track_class' set.
-            # We can get for it all the necessary and possible keywords
+                raise InputError(f"Section {section_name}: there is no file_type nor file specified and it is not a "
+                                 f"[spacer] nor a [x-axis] section. This is not a valid section.")
+            # Now we should have a 'track_class' set. We can get for it all the necessary and possible keywords
             track_class = track_options['track_class']
             NECESSARY_PROPERTIES = track_class.NECESSARY_PROPERTIES
             for necessary_name in NECESSARY_PROPERTIES:
                 if necessary_name not in all_keywords:
-                    raise InputError(f"The section {section_name} is "
-                                     "describing a object of"
-                                     f" type {track_class} but the necessary "
-                                     f"property {necessary_name}"
-                                     " is not part of the config file.")
+                    raise InputError(f"The section {section_name} is describing a object of type {track_class} but "
+                                     f"the necessary property {necessary_name} is not part of the config file.")
             unused_keys = []
             # Now we can proceed with the keywords:
             for name, value in parser.items(section_name):
@@ -633,73 +643,46 @@ class PlotTracks(object):
                 if ' ' in name:
                     old_name = name
                     name = '_'.join(name.split(' '))
-                    log.warning(f"Deprecated Warning: The section {section_name} "
-                                f"uses parameter {old_name} but there is no more "
-                                "parameter with space in name. "
-                                f"Will be substituted by {name}.\n")
+                    log.warning(f"Deprecated Warning: The section {section_name} uses parameter {old_name} but there "
+                                f"is no more parameter with space in name. Will be substituted by {name}.\n")
                 else:
                     old_name = name
-                # end
                 SYNONYMOUS_PROPERTIES = track_class.SYNONYMOUS_PROPERTIES
-                # If the name is part of the synonymous we substitute by
-                # the synonymous value
-                if name in SYNONYMOUS_PROPERTIES and \
-                   value in SYNONYMOUS_PROPERTIES[name]:
+                # If the name is part of the synonymous we substitute by the synonymous value
+                if name in SYNONYMOUS_PROPERTIES and value in SYNONYMOUS_PROPERTIES[name]:
                     track_options[name] = SYNONYMOUS_PROPERTIES[name][value]
                 elif name in track_class.STRING_PROPERTIES:
                     track_options[name] = value
                 elif name in track_class.BOOLEAN_PROPERTIES:
                     try:
-                        # I need to use old_name here else I get a KeyError:
-                        track_options[name] = parser.getboolean(section_name,
-                                                                old_name)
-                        # In the next 1.0 should be:
-                        # track_options[name] = parser.getboolean(section_name,
-                        #                                         name)
+                        # I need to use old_name here else I get a KeyError
+                        track_options[name] = parser.getboolean(section_name, old_name)
                     except ValueError:
-                        raise InputError(f"In section {section_name}, "
-                                         f"{old_name} was set to {value}"
-                                         " whereas we should have a boolean "
-                                         "value. Please, use true or false.")
-                        # In the next 1.0 should be:
-                        #                f"{name} was set to {value}"
+                        raise InputError(f"In section {section_name}, {old_name} was set to {value} whereas we should "
+                                         f"have a boolean value. Please, use true or false.")
                     if value.lower() not in ['true', 'false']:
-                        log.warning("Deprecation Warning: "
-                                    f"In section {section_name}, {name} was "
-                                    f"set to {value}"
-                                    " whereas in the future only"
-                                    " true and false value will be"
-                                    " accepted.\n")
+                        log.warning(f"Deprecation Warning: In section {section_name}, {name} was set to {value} "
+                                    f"whereas in the future only true and false value will be accepted.\n")
                 elif name in track_class.FLOAT_PROPERTIES:
                     try:
                         track_options[name] = float(value)
                     except ValueError:
-                        raise InputError(f"In section {section_name}, {name} "
-                                         f"was set to {value}"
-                                         " whereas we should have a float "
-                                         "value.")
+                        raise InputError(f"In section {section_name}, {name} was set to {value} whereas we should have "
+                                         f"a float value.")
                     min_value, max_value = track_class.FLOAT_PROPERTIES[name]
-                    if track_options[name] < min_value or \
-                       track_options[name] > max_value:
-                        raise InputError(f"In section {section_name}, {name} "
-                                         f"was set to {value}"
-                                         " whereas it should be between "
-                                         f"{min_value} and {max_value}.")
+                    if track_options[name] < min_value or track_options[name] > max_value:
+                        raise InputError(f"In section {section_name}, {name} was set to {value} whereas it should be "
+                                         f"between {min_value} and {max_value}.")
                 elif name in track_class.INTEGER_PROPERTIES:
                     try:
                         track_options[name] = int(value)
                     except ValueError:
-                        raise InputError(f"In section {section_name}, {name} "
-                                         f"was set to {value}"
-                                         " whereas we should have an integer "
-                                         "value.")
+                        raise InputError(f"In section {section_name}, {name} was set to {value} whereas we should have "
+                                         f"an integer value.")
                     min_value, max_value = track_class.INTEGER_PROPERTIES[name]
-                    if track_options[name] < min_value or \
-                       track_options[name] > max_value:
-                        raise InputError(f"In section {section_name}, {name} "
-                                         f"was set to {value}"
-                                         " whereas it should be between "
-                                         f"{min_value} and {max_value}.")
+                    if track_options[name] < min_value or track_options[name] > max_value:
+                        raise InputError(f"In section {section_name}, {name} was set to {value} whereas it should be "
+                                         f"between {min_value} and {max_value}.")
                 else:
                     unused_keys.append(name)
             # If there are unused keys they are printed in a warning.
@@ -745,14 +728,13 @@ class PlotTracks(object):
     @staticmethod
     def check_file_exists(track_dict, tracks_path, is_hic=False):
         """
-        Checks if a file or list of files exists. If the file does not exists
-        tries to check if the file may be relative to the track_file path,
-        in such case the path is updated.
-        :param track_dict: dictionary of track values. Should contain
-                            a 'file' key containing the path of the file
-                            or files to be checked separated by space
-                            For example: file1 file2 file3
+        Checks if a file or list of files exists. If the file does not exist, tries to check if the file may be
+        relative to the track_file path, in such case the path is updated.
+
+        :param track_dict: dictionary of track values. Should contain a 'file' key containing the path of the file or
+                           files to be checked separated by space. For example: file1 file2 file3
         :param tracks_path: path of the tracks file
+        :param is_hic: if True, the file extension is not checked
         :return: None
         """
         for key in track_dict.keys():
@@ -796,12 +778,9 @@ class PlotTracks(object):
     def guess_filetype(track_dict, available_tracks):
         """
 
-        :param track_dict: dictionary of track values with the 'file' key
-                    containing a string path of the file or files.
-                    Only the ending of the last file is used
-                    in case when there are more files
-        :param: available_tracks: list of available tracks
-
+        :param track_dict: dictionary of track values with the 'file' key containing a string path of the file or files.
+                    Only the ending of the last file is used in case when there are more files.
+        :param available_tracks: list of available tracks
         :return: string file type detected
         """
         file_ = track_dict['file'].strip()
@@ -810,15 +789,13 @@ class PlotTracks(object):
             for ending in track_class.SUPPORTED_ENDINGS:
                 if file_.endswith(ending):
                     if file_type == track_class.TRACK_TYPE:
-                        raise InputError("file_type already defined in other"
-                                         " GenomeTrack")
+                        raise InputError("file_type already defined in other GenomeTrack")
                     else:
                         file_type = track_class.TRACK_TYPE
 
         if file_type is None:
-            raise InputError(f"Section {track_dict['section_name']}: can not "
-                             "identify file type. Please"
-                             f" specify the file_type for '{file_}'")
+            raise InputError(f"Section {track_dict['section_name']}: can not identify file type. Please specify the "
+                             f"file_type for '{file_}'")
 
         return file_type
 

--- a/pygenometracks/tracksClass.py
+++ b/pygenometracks/tracksClass.py
@@ -639,14 +639,14 @@ class PlotTracks(object):
             unused_keys = []
             # Now we can proceed with the keywords:
             for name, value in parser.items(section_name):
-                # To be removed in the next 1.0 version
-                if ' ' in name:
+                if ' ' in name:  # Deal with spaces in the name
                     old_name = name
                     name = '_'.join(name.split(' '))
                     log.warning(f"Deprecated Warning: The section {section_name} uses parameter {old_name} but there "
                                 f"is no more parameter with space in name. Will be substituted by {name}.\n")
                 else:
                     old_name = name
+
                 SYNONYMOUS_PROPERTIES = track_class.SYNONYMOUS_PROPERTIES
                 # If the name is part of the synonymous we substitute by the synonymous value
                 if name in SYNONYMOUS_PROPERTIES and value in SYNONYMOUS_PROPERTIES[name]:

--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,6 @@ setup(
         'Topic :: Scientific/Engineering :: Bio-Informatics'],
     install_requires=install_requires_py,
     zip_safe=False,
-    python_requires='>=3.7.*, <4',
+    python_requires='>=3.7, <4',
     cmdclass={'sdist': sdist, 'install': install}
 )


### PR DESCRIPTION
A while back I created a "GWAS track" for personal use to display individual genetic variants in a scatterplot as a separate track.
It is quite rough, as it was done _ad hoc_.
It takes data in the IGV _.gwas_ format (see: https://igv.org/doc/desktop/#FileFormats/DataTracks/#gwas)
I just wanted to gauge interest in making this a proper addition to the tool.
Is this in scope? What would be needed for a proper pull request?

Example image:
![pr_example](https://github.com/user-attachments/assets/b3806b4c-eb4e-4b79-a5b1-68c18aa082e9)
