### PR TITLE
Remove anaconda usage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ stages:
       timeoutInMinutes: 0
       pool:
         vmImage: 'Ubuntu-latest'
-      container: python:3.8
+      container: python:3.12
       steps:
       - bash: |
           echo "##vso[task.prependpath]$HOME/.local/bin"
@@ -45,26 +45,23 @@ stages:
 
       steps:
       - bash: |
-          echo "##vso[task.prependpath]$CONDA/bin"
-          hash -r
-        displayName: Add conda to PATH
+          "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
+        displayName: Install micromamba
       - bash: |
-          conda config --set always_yes yes --set changeps1 no
-          conda info -a
           cat requirements_CI.txt | awk -v v=$(matplotlib.version) -v vp=$(python.version) 'BEGIN{print "python =="vp}{if($0~/matplotlib/){$0="matplotlib =="v}; print}' > requirements_CI_updated.txt
-          conda create -n pygenometracks --yes -c conda-forge -c bioconda --file requirements_CI_updated.txt
-          source activate pygenometracks
+          micromamba create -n pygenometracks --yes -c conda-forge -c bioconda --file requirements_CI_updated.txt
+          micromamba activate pygenometracks
           python -m pip install .
         displayName: installing dependencies
       - script: |
-          source activate pygenometracks
+          eval "$(micromamba shell hook --shell bash)"
+          micromamba activate pygenometracks
           py.test pygenometracks --doctest-modules -n 4
         displayName: pytest
-
     - job: OSX
       timeoutInMinutes: 0
       pool:
-        vmImage: 'macOS-11'
+        vmImage: 'macOS-latest'
       strategy:
         matrix:
           Python38LowMatplotlib:
@@ -76,25 +73,21 @@ stages:
           Python39HighMatplotlib:
             python.version: '3.9'
             matplotlib.version: '3.5.1'
-
       steps:
       - bash: |
-          echo "##vso[task.prependpath]$CONDA/bin"
-          hash -r
-        displayName: Add conda to PATH
-      # On Hosted macOS, the agent user doesn't have ownership of Miniconda's installation directory/
-      # We need to take ownership if we want to update conda or install packages globally
-      - bash: sudo chown -R $USER $CONDA
-        displayName: Take ownership of conda installation
+          brew install micromamba
+        displayName: Install micromamba
       - bash: |
-          conda config --set always_yes yes --set changeps1 no
-          conda info -a
+          eval "$(micromamba shell hook --shell bash)"
           cat requirements_CI.txt | awk -v v=$(matplotlib.version) -v vp=$(python.version) 'BEGIN{print "python =="vp}{if($0~/matplotlib/){$0="matplotlib =="v}; print}' > requirements_CI_updated.txt
-          conda create -n pygenometracks --yes -c conda-forge -c bioconda --file requirements_CI_updated.txt
+          micromamba create -n pygenometracks --yes -c conda-forge -c bioconda --file requirements_CI_updated.txt
+          micromamba activate pygenometracks
+          echo $PATH
           python -m pip install .
         displayName: installing dependencies
       - script: |
-          source activate pygenometracks
+          eval "$(micromamba shell hook --shell bash)"
+          micromamba activate pygenometracks
           py.test pygenometracks --doctest-modules -n 4
         displayName: pytest
 

--- a/requirements_CI.txt
+++ b/requirements_CI.txt
@@ -8,7 +8,7 @@ pysam >=0.14
 gffutils >=0.9
 pybedtools >=0.8.1
 tqdm >=4.20
-bx-python >=0.8.13
+bx-python >=0.8.13, <0.13.0
 pyfaidx >=0.1.3
 # Below are dependencies for tests
 pytest


### PR DESCRIPTION
This PR get rid of anaconda usage and use micromamba.
Additionally it pins a max version for bx-python in order to make tests pass.

I think could be merged to master as it only involves CI.